### PR TITLE
レイアウト調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ server/insert_*.sql
 
 # Server Environment
 server/.env
+*.env
+setup_env.sh
+infra_setup.sh
+final_infra_setup.sh
+server/setup_env.sh
+server/final_infra_setup.sh

--- a/server/db.js
+++ b/server/db.js
@@ -1,6 +1,6 @@
 const { Pool } = require('pg');
 const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '.env') });
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 
 const pool = new Pool({
     user: process.env.DB_USER || 'uver_user',

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '.env') });
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 
 const app = express();
 const PORT = process.env.PORT || 8000;

--- a/src/components/Auth/AuthLayout.jsx
+++ b/src/components/Auth/AuthLayout.jsx
@@ -42,9 +42,13 @@ const AuthLayout = ({ children, title, subtitle }) => {
                             fontSize: '1.8rem',
                             color: '#fff',
                             margin: '0 0 10px 0',
-                            letterSpacing: '1px'
+                            letterSpacing: '1px',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            lineHeight: '1.1'
                         }}>
-                            <span style={{ color: 'var(--primary-color)' }}>UVERworld</span><br />
+                            <span style={{ color: 'var(--primary-color)' }}>UVERworld</span>
                             <span style={{ fontSize: '0.9rem', color: '#64748b', fontWeight: 'normal', letterSpacing: '2px' }}>Setlist Archive</span>
                         </h1>
                     </Link>

--- a/src/components/Dashboard/AlbumDistribution.jsx
+++ b/src/components/Dashboard/AlbumDistribution.jsx
@@ -3,6 +3,24 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Cartes
 
 const COLORS = ['#d4af37', '#fbbf24', '#b91c1c', '#3b82f6', '#10b981', '#6366f1', '#8b5cf6'];
 
+const CustomYAxisTick = ({ x, y, payload, fontSize }) => {
+    return (
+        <g transform={`translate(${x},${y})`}>
+            <text
+                x={0}
+                y={0}
+                dy={4}
+                textAnchor="end"
+                fill="#888"
+                fontSize={fontSize}
+                style={{ whiteSpace: 'nowrap' }} // SVG doesn't strictly obey this but it helps in some contexts, main thing is <text> doesn't wrap by default
+            >
+                {payload.value}
+            </text>
+        </g>
+    );
+};
+
 const AlbumDistribution = ({ data, onBarClick }) => {
     if (!data || data.length === 0) return <div className="no-data">No Album Data</div>;
 
@@ -22,16 +40,33 @@ const AlbumDistribution = ({ data, onBarClick }) => {
         ticks.push(i);
     }
 
+    // Responsive width for YAxis
+    const [yAxisConfig, setYAxisConfig] = React.useState({ width: 120, fontSize: 11 });
+
+    React.useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth <= 480) {
+                setYAxisConfig({ width: 60, fontSize: 9 });
+            } else {
+                setYAxisConfig({ width: 120, fontSize: 11 });
+            }
+        };
+
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
     return (
         <div style={{ width: '100%', height: calculatedHeight, minHeight: 0 }}>
-            <ResponsiveContainer>
-                <BarChart data={data} layout="vertical" margin={{ top: 5, right: 30, left: 10, bottom: 5 }}>
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+                <BarChart data={data} layout="vertical" margin={{ top: 5, right: 30, left: 0, bottom: 5 }}>
                     <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#444" />
                     <XAxis
                         type="number"
                         stroke="#fbbf24"
                         allowDecimals={false}
-                        tick={{ fill: '#fbbf24' }}
+                        tick={{ fill: '#fbbf24', fontSize: 11 }}
                         domain={[0, 'auto']}
                         ticks={ticks}
                     />
@@ -39,8 +74,8 @@ const AlbumDistribution = ({ data, onBarClick }) => {
                         type="category"
                         dataKey="name"
                         stroke="#888"
-                        width={180}
-                        tick={{ fontSize: 11, width: 170 }}
+                        width={yAxisConfig.width}
+                        tick={<CustomYAxisTick fontSize={yAxisConfig.fontSize} />}
                         interval={0}
                     />
                     <Tooltip

--- a/src/components/Dashboard/AttendedLiveList.jsx
+++ b/src/components/Dashboard/AttendedLiveList.jsx
@@ -52,9 +52,9 @@ const AttendedLiveList = ({ lives }) => {
                 <h3>参戦履歴</h3>
 
                 {/* Controls */}
-                <div style={{ display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap' }}>
+                <div className="controls-container">
                     {/* Search Input */}
-                    <div style={{ position: 'relative' }}>
+                    <div className="control-item search-item" style={{ position: 'relative' }}>
                         <Search size={16} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: '#64748b' }} />
                         <input
                             type="text"
@@ -68,13 +68,13 @@ const AttendedLiveList = ({ lives }) => {
                                 background: 'rgba(255,255,255,0.05)',
                                 color: 'white',
                                 fontSize: '0.9rem',
-                                width: '200px'
+                                width: '100%'
                             }}
                         />
                     </div>
 
                     {/* Year Filter */}
-                    <div style={{ position: 'relative' }}>
+                    <div className="control-item" style={{ position: 'relative' }}>
                         <Filter size={16} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: '#64748b' }} />
                         <select
                             value={selectedYear}
@@ -88,7 +88,8 @@ const AttendedLiveList = ({ lives }) => {
                                 fontSize: '0.9rem',
                                 appearance: 'none',
                                 cursor: 'pointer',
-                                paddingRight: '30px'
+                                paddingRight: '30px',
+                                width: '100%'
                             }}
                         >
                             <option value="ALL">全期間</option>
@@ -100,6 +101,7 @@ const AttendedLiveList = ({ lives }) => {
 
                     {/* Sort Toggle */}
                     <button
+                        className="control-item"
                         onClick={toggleSort}
                         style={{
                             display: 'flex',
@@ -112,7 +114,9 @@ const AttendedLiveList = ({ lives }) => {
                             color: 'white',
                             fontSize: '0.9rem',
                             cursor: 'pointer',
-                            transition: 'background 0.2s'
+                            transition: 'background 0.2s',
+                            width: '100%',
+                            justifyContent: 'center'
                         }}
                     >
                         <ArrowUpDown size={16} />
@@ -176,6 +180,25 @@ const AttendedLiveList = ({ lives }) => {
                 }
                 .compact-live-item:hover {
                     background: rgba(255, 255, 255, 0.03);
+                }
+
+                .controls-container {
+                    display: flex;
+                    gap: 10px;
+                    align-items: center;
+                    flex-wrap: wrap;
+                    width: 100%;
+                }
+                
+                @media (max-width: 640px) {
+                    .controls-container {
+                        display: grid;
+                        grid-template-columns: 1fr 1fr;
+                        gap: 10px;
+                    }
+                    .search-item {
+                        grid-column: 1 / -1;
+                    }
                 }
             `}</style>
         </div>

--- a/src/components/Dashboard/AttendedLiveList.jsx
+++ b/src/components/Dashboard/AttendedLiveList.jsx
@@ -101,7 +101,7 @@ const AttendedLiveList = ({ lives }) => {
 
                     {/* Sort Toggle */}
                     <button
-                        className="control-item"
+                        className="control-item sort-btn"
                         onClick={toggleSort}
                         style={{
                             display: 'flex',
@@ -115,8 +115,7 @@ const AttendedLiveList = ({ lives }) => {
                             fontSize: '0.9rem',
                             cursor: 'pointer',
                             transition: 'background 0.2s',
-                            width: '100%',
-                            justifyContent: 'center'
+                            whiteSpace: 'nowrap'
                         }}
                     >
                         <ArrowUpDown size={16} />
@@ -186,8 +185,17 @@ const AttendedLiveList = ({ lives }) => {
                     display: flex;
                     gap: 10px;
                     align-items: center;
-                    flex-wrap: wrap;
-                    width: 100%;
+                    flex: 1;
+                }
+
+                .search-item {
+                    flex: 1;
+                    min-width: 200px;
+                }
+
+                .control-item select,
+                .control-item.sort-btn {
+                    width: auto !important;
                 }
                 
                 @media (max-width: 640px) {
@@ -195,9 +203,14 @@ const AttendedLiveList = ({ lives }) => {
                         display: grid;
                         grid-template-columns: 1fr 1fr;
                         gap: 10px;
+                        width: 100%;
                     }
                     .search-item {
                         grid-column: 1 / -1;
+                    }
+                    .control-item select,
+                    .control-item.sort-btn {
+                        width: 100% !important;
                     }
                 }
             `}</style>

--- a/src/components/Dashboard/LiveGraph.jsx
+++ b/src/components/Dashboard/LiveGraph.jsx
@@ -44,13 +44,27 @@ const LiveGraph = ({ data, onBarClick, dataKey = "count", label }) => {
         }
     };
 
+    // Responsive width for YAxis
+    const [yWidth, setYWidth] = React.useState(40);
+
+    React.useEffect(() => {
+        const handleResize = () => {
+            setYWidth(window.innerWidth <= 480 ? 30 : 40);
+        };
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
     return (
         <div style={{ width: '100%', height: 300 }}>
-            <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={data}>
-                    <XAxis dataKey="year" stroke="#888" />
+            <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+                <BarChart data={data} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
+                    <XAxis dataKey="year" stroke="#888" tick={{ fontSize: 11 }} />
                     <YAxis
                         stroke="#888"
+                        width={yWidth}
+                        tick={{ fontSize: 11 }}
                         allowDecimals={dataKey === 'avgSongs'}
                     />
                     <Tooltip

--- a/src/components/Dashboard/UpcomingLives.jsx
+++ b/src/components/Dashboard/UpcomingLives.jsx
@@ -10,10 +10,12 @@ export const UpcomingLives = ({ lives }) => {
 
     return (
         <div style={{ marginBottom: '50px' }}>
-            <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <Sparkles size={20} color="#fbbf24" style={{ animation: 'pulse 2s infinite' }} />
-                Next Live
-                <span style={{ fontSize: '0.8rem', color: '#888', fontWeight: 'normal' }}>
+            <h2 className="section-title next-live-header" style={{ marginBottom: '20px' }}>
+                <div className="next-live-label">
+                    <Sparkles size={20} color="#fbbf24" style={{ animation: 'pulse 2s infinite' }} />
+                    Next Live
+                </div>
+                <span className="next-live-sub">
                     （セットリスト予想 - Coming Soon）
                 </span>
             </h2>
@@ -102,21 +104,6 @@ export const UpcomingLives = ({ lives }) => {
                                 >
                                     <Sparkles size={14} /> 予想する (準備中)
                                 </button>
-                                {/* AI Prediction Badge (Placeholder) */}
-                                {/* 
-                                <div style={{
-                                    padding: '0 10px',
-                                    display: 'flex', alignItems: 'center',
-                                    background: 'rgba(56, 189, 248, 0.1)',
-                                    color: '#38bdf8',
-                                    borderRadius: '8px',
-                                    fontSize: '0.75rem',
-                                    fontWeight: 'bold',
-                                    border: '1px solid rgba(56, 189, 248, 0.2)'
-                                }}>
-                                    AI
-                                </div>
-                                */}
                             </div>
                         </div>
                     </div>
@@ -133,6 +120,37 @@ export const UpcomingLives = ({ lives }) => {
                     transform: translateY(-5px);
                     border-color: rgba(251, 191, 36, 0.3) !important;
                     transition: all 0.3s ease;
+                }
+
+                /* Responsive Header for Next Live */
+                .next-live-header {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                    flex-wrap: wrap;
+                }
+                .next-live-label {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+                    white-space: nowrap; /* Prevent "Next Live" line break */
+                }
+                .next-live-sub {
+                    font-size: 0.8rem;
+                    color: #888;
+                    font-weight: normal;
+                }
+
+                @media (max-width: 480px) {
+                    .next-live-header {
+                        flex-direction: column;
+                        align-items: flex-start;
+                        gap: 2px;
+                    }
+                    .next-live-sub {
+                        font-size: 0.75rem;
+                        margin-left: 30px; /* Align with text, skipping icon width */
+                    }
                 }
             `}</style>
         </div>

--- a/src/components/Dashboard/VenueRanking.jsx
+++ b/src/components/Dashboard/VenueRanking.jsx
@@ -44,7 +44,7 @@ const VenueRanking = ({ venues, onVenueClick }) => {
                     <div style={{ flexGrow: 1, fontWeight: '500' }}>
                         {venue.name}
                     </div>
-                    <div style={{ color: '#fbbf24', fontWeight: 'bold' }}>
+                    <div style={{ color: '#fbbf24', fontWeight: 'bold', whiteSpace: 'nowrap', flexShrink: 0 }}>
                         {venue.count}回
                     </div>
                 </div>

--- a/src/components/Dashboard/VenueTypePie.jsx
+++ b/src/components/Dashboard/VenueTypePie.jsx
@@ -6,6 +6,18 @@ const COLORS = ['#d4af37', '#fbbf24', '#b91c1c', '#FFFFFF'];
 const VenueTypeBar = ({ data, onBarClick }) => {
     if (!data || data.length === 0) return <div className="no-data">No Data</div>;
 
+    // Responsive width for YAxis
+    const [yWidth, setYWidth] = React.useState(100);
+
+    React.useEffect(() => {
+        const handleResize = () => {
+            setYWidth(window.innerWidth <= 480 ? 70 : 100);
+        };
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
     const handleClick = (data) => {
         if (onBarClick && data && data.name) {
             onBarClick(data.name);
@@ -17,7 +29,7 @@ const VenueTypeBar = ({ data, onBarClick }) => {
             <ResponsiveContainer>
                 <BarChart data={data} layout="vertical">
                     <XAxis type="number" stroke="#888" allowDecimals={false} />
-                    <YAxis type="category" dataKey="name" stroke="#888" width={100} />
+                    <YAxis type="category" dataKey="name" stroke="#888" width={yWidth} tick={{ fontSize: 11 }} />
                     <Tooltip
                         contentStyle={{ backgroundColor: '#1e293b', borderColor: '#333', color: '#fff' }}
                         itemStyle={{ color: '#d4af37' }}

--- a/src/components/Layout/Navbar.jsx
+++ b/src/components/Layout/Navbar.jsx
@@ -48,7 +48,7 @@ const Navbar = () => {
                         </Link>
                         {currentUser && (
                             <Link to="/mypage" className="nav-link">
-                                <User size={18} /> マイページ
+                                <User size={18} /> My Page
                             </Link>
                         )}
 
@@ -84,7 +84,7 @@ const Navbar = () => {
                     <Link to="/" className="mobile-nav-link">Home</Link>
                     <Link to="/songs" className="mobile-nav-link">Discography</Link>
                     <Link to="/lives" className="mobile-nav-link">Archive</Link>
-                    {currentUser && <Link to="/mypage" className="mobile-nav-link">マイページ</Link>}
+                    {currentUser && <Link to="/mypage" className="mobile-nav-link">My Page</Link>}
 
                     <div className="mobile-nav-divider"></div>
                     {currentUser ? (

--- a/src/components/Layout/Navbar.jsx
+++ b/src/components/Layout/Navbar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Menu, X, User, Calendar, LogIn, LogOut, Shield, ListMusic, AlertTriangle } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -8,6 +8,12 @@ const Navbar = () => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const location = useLocation();
     const { currentUser, logout } = useAuth();
+    const navigate = useNavigate();
+
+    const handleLogout = () => {
+        logout();
+        navigate('/');
+    };
 
     // Handle scroll effect
     useEffect(() => {
@@ -58,7 +64,7 @@ const Navbar = () => {
                             </Link>
                         )}
                         {currentUser ? (
-                            <button onClick={logout} className="nav-btn-primary" style={{ textDecoration: 'none' }}>
+                            <button onClick={handleLogout} className="nav-btn-primary" style={{ textDecoration: 'none' }}>
                                 <LogOut size={18} /> ログアウト
                             </button>
                         ) : (
@@ -88,7 +94,7 @@ const Navbar = () => {
 
                     <div className="mobile-nav-divider"></div>
                     {currentUser ? (
-                        <button onClick={logout} className="mobile-nav-btn" style={{ textDecoration: 'none', display: 'inline-block' }}>ログアウト</button>
+                        <button onClick={handleLogout} className="mobile-nav-btn" style={{ textDecoration: 'none', display: 'inline-block' }}>ログアウト</button>
                     ) : (
                         <Link to="/login" className="mobile-nav-btn" style={{ textDecoration: 'none', display: 'inline-block' }}>ログイン / 新規登録</Link>
                     )}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -352,7 +352,7 @@ function Dashboard() {
                     <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
                             <Trophy size={20} color="var(--primary-color)" />
-                            Top Songs <span style={{ fontSize: '0.8rem', color: '#888', fontWeight: 'normal' }}>(Top 10)</span>
+                            Top Songs
                         </h2>
                         <div className="dashboard-panel" style={{ padding: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
                             {(!stats.globalSongRanking || stats.globalSongRanking.length === 0) ? (

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,7 +3,7 @@ import { DISCOGRAPHY } from '../data/discography';
 import PageHeader from '../components/Layout/PageHeader';
 import { Link, useLocation } from 'react-router-dom';
 import { useGlobalStats } from '../hooks/useGlobalStats';
-import { Calendar, Music, MapPin, ArrowRight, List, TrendingUp, Activity, Filter, Disc } from 'lucide-react';
+import { Calendar, Music, MapPin, ArrowRight, List, TrendingUp, Activity, Filter, Disc, Trophy, History } from 'lucide-react';
 import LiveGraph from '../components/Dashboard/LiveGraph';
 import AlbumDistribution from '../components/Dashboard/AlbumDistribution';
 import { LatestLiveCard } from '../components/Dashboard/LatestLiveCard';
@@ -240,7 +240,7 @@ function Dashboard() {
                 {stats.currentTour && (
                     <div style={{ marginBottom: '40px' }}>
                         <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
-                            <Music size={20} />
+                            <Music size={20} color="var(--primary-color)" />
                             TOUR HIGHLIGHTS
                         </h2>
                         <TourTrends tour={stats.currentTour} />
@@ -249,7 +249,7 @@ function Dashboard() {
 
                 {/* Stats Cards */}
                 <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
-                    <Activity size={20} />
+                    <Activity size={20} color="var(--primary-color)" />
                     HISTORY
                 </h2>
                 <div style={{
@@ -282,11 +282,9 @@ function Dashboard() {
                 {/* Yearly Chart */}
                 <div style={{ marginBottom: '60px' }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '20px', flexWrap: 'wrap', gap: '15px' }}>
-                        <h2 className="section-title" style={{ marginBottom: 0 }}>
-                            Trend Analysis
-                            <span style={{ fontSize: '0.8rem', color: '#888', fontWeight: 'normal', marginLeft: '10px' }}>
-                                (年度別統計)
-                            </span>
+                        <h2 className="section-title" style={{ marginBottom: 0, display: 'flex', alignItems: 'center', gap: '10px' }}>
+                            <TrendingUp size={20} color="var(--primary-color)" />
+                            Yearly Trends
                         </h2>
 
                         <div style={{ display: 'flex', gap: '10px', background: 'rgba(255,255,255,0.05)', padding: '4px', borderRadius: '8px' }}>
@@ -352,7 +350,10 @@ function Dashboard() {
                 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '40px', marginBottom: '60px' }}>
                     {/* Top Songs Ranking (Left Column) */}
                     <div style={{ display: 'flex', flexDirection: 'column' }}>
-                        <h2 className="section-title" style={{ marginBottom: '20px' }}>Top Songs <span style={{ fontSize: '0.8rem', color: '#888', fontWeight: 'normal' }}>(Top 10)</span></h2>
+                        <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
+                            <Trophy size={20} color="var(--primary-color)" />
+                            Top Songs <span style={{ fontSize: '0.8rem', color: '#888', fontWeight: 'normal' }}>(Top 10)</span>
+                        </h2>
                         <div className="dashboard-panel" style={{ padding: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
                             {(!stats.globalSongRanking || stats.globalSongRanking.length === 0) ? (
                                 <div style={{ padding: '40px', textAlign: 'center', color: '#64748b', flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -415,9 +416,12 @@ function Dashboard() {
 
                     {/* Recent Lives (Right Column) */}
                     <div style={{ display: 'flex', flexDirection: 'column' }}>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
-                            <h2 className="section-title" style={{ marginBottom: 0 }}>Recent Lives</h2>
-                            <Link to="/lives" style={{ color: 'var(--accent-color)', fontSize: '0.9rem' }}>View All</Link>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '20px' }}>
+                            <h2 className="section-title" style={{ marginBottom: 0, display: 'flex', alignItems: 'center', gap: '10px' }}>
+                                <History size={20} color="var(--primary-color)" />
+                                Recent Lives
+                            </h2>
+                            <Link to="/lives" style={{ color: '#94a3b8', fontSize: '0.85rem', textDecoration: 'none' }}>View All &rarr;</Link>
                         </div>
                         <div className="dashboard-panel" style={{ padding: '0', flex: 1, display: 'flex', flexDirection: 'column' }}>
                             {(!stats.recentLives || stats.recentLives.length === 0) ? (
@@ -565,7 +569,10 @@ function Dashboard() {
 
                 {/* Past Tour Analysis (New Section) */}
                 <div style={{ marginTop: '60px', marginBottom: '100px' }}>
-                    <h2 className="section-title" style={{ marginBottom: '20px' }}>Past Tour Analysis</h2>
+                    <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
+                        <List size={20} color="var(--primary-color)" />
+                        Past Tour Analysis
+                    </h2>
 
                     <div className="dashboard-panel">
                         <div style={{ marginBottom: '20px' }}>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -318,7 +318,7 @@ function Dashboard() {
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
                             <div style={{ fontSize: '0.85rem', color: '#64748b', display: 'flex', alignItems: 'center', gap: '8px' }}>
                                 <Filter size={14} />
-                                期間: {yearRange[0]} - {yearRange[1]}
+                                {yearRange[0]} - {yearRange[1]}
                             </div>
                             <div style={{ display: 'flex', gap: '8px' }}>
                                 <input
@@ -486,7 +486,7 @@ function Dashboard() {
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
                             <div style={{ fontSize: '0.85rem', color: '#64748b', display: 'flex', alignItems: 'center', gap: '8px' }}>
                                 <Filter size={14} />
-                                期間: {yearRange[0]} - {yearRange[1]}
+                                {yearRange[0]} - {yearRange[1]}
                             </div>
                             <div style={{ display: 'flex', gap: '8px' }}>
                                 <input

--- a/src/pages/LandingPage.css
+++ b/src/pages/LandingPage.css
@@ -585,7 +585,8 @@
 
     /* Header responsive */
     .lp-header-container {
-        padding: 0 20px;
+        padding: 0 15px;
+        /* Reduce padding to give more space */
     }
 
     .lp-logo-text {
@@ -593,16 +594,21 @@
     }
 
     .lp-nav {
-        gap: 12px;
+        gap: 10px;
+        /* Reduce gap */
     }
 
     .lp-nav-link {
         font-size: 0.85rem;
+        white-space: nowrap;
+        /* Prevent wrapping */
     }
 
     .lp-nav-btn {
-        padding: 6px 16px;
+        padding: 6px 14px;
         font-size: 0.85rem;
+        white-space: nowrap;
+        /* Prevent wrapping */
     }
 }
 
@@ -613,5 +619,24 @@
 
     .lp-section-title {
         font-size: 1.8rem;
+    }
+
+    /* Further adjustment for very small screens (iPhone SE etc) */
+    .lp-logo-text {
+        font-size: 0.9rem;
+    }
+
+    /* Hide "Setlist Archive" if screens are too narrow, or just shrink more? 
+       Let's try flex-shrink on logo text to allow truncation if needed */
+    .lp-logo {
+        flex: 1;
+        min-width: 0;
+        margin-right: 10px;
+    }
+
+    .lp-logo-text {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import SEO from '../components/SEO';
 import { Music, BarChart3, Heart, ChevronDown, AlertTriangle, User, ShieldAlert, Mail } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
 import './LandingPage.css';
 
 const LandingPage = () => {
+    const { currentUser, logout } = useAuth();
+    const navigate = useNavigate();
+
+    const handleLogout = () => {
+        logout();
+        navigate('/');
+    };
     return (
         <div className="landing-page">
             <SEO
@@ -19,8 +27,17 @@ const LandingPage = () => {
                         <span className="lp-logo-text"><span className="text-gold">UVERworld</span> Setlist Archive</span>
                     </Link>
                     <nav className="lp-nav">
-                        <Link to="/login" className="lp-nav-link">ログイン</Link>
-                        <Link to="/signup" className="lp-nav-btn">新規登録</Link>
+                        {currentUser ? (
+                            <>
+                                <Link to="/mypage" className="lp-nav-link">My Page</Link>
+                                <button onClick={handleLogout} className="lp-nav-btn">ログアウト</button>
+                            </>
+                        ) : (
+                            <>
+                                <Link to="/login" className="lp-nav-link">ログイン</Link>
+                                <Link to="/signup" className="lp-nav-btn">新規登録</Link>
+                            </>
+                        )}
                     </nav>
                 </div>
             </header>

--- a/src/pages/LiveDetail.jsx
+++ b/src/pages/LiveDetail.jsx
@@ -15,6 +15,7 @@ function LiveDetail() {
     const { currentUser } = useAuth();
     const [isCorrectionModalOpen, setIsCorrectionModalOpen] = useState(false);
     const navigate = useNavigate();
+    const location = useLocation();
 
     const handleCorrectionClick = () => {
         if (!currentUser) {
@@ -70,9 +71,6 @@ function LiveDetail() {
     const setlist = live.setlist || [];
     const mainTitle = live.tour_name || live.title || "Unknown Live";
 
-    const location = useLocation();
-
-    // Determine back link destination
     // Determine back link destination
     const backLink = location.state?.from || '/lives';
     let backLabel = 'アーカイブに戻る';

--- a/src/pages/LiveList.jsx
+++ b/src/pages/LiveList.jsx
@@ -179,18 +179,18 @@ const LiveList = () => {
                     ) : (
                         filteredLives.map(live => (
                             <Link to={`/live/${live.id}`} state={{ from: location.pathname }} key={live.id} className="block group">
-                                <div className="bg-slate-800/50 hover:bg-slate-800 border border-slate-700 hover:border-blue-500/50 rounded-xl p-5 transition-all duration-300 hover:transform hover:-translate-y-1 hover:shadow-lg hover:shadow-blue-900/20 relative overflow-hidden">
+                                <div className="bg-slate-800/50 hover:bg-slate-800 border border-slate-700 hover:border-blue-500/50 rounded-xl px-4 py-3 transition-all duration-300 hover:transform hover:-translate-y-1 hover:shadow-lg hover:shadow-blue-900/20 relative overflow-hidden">
                                     {/* Left accent border */}
                                     <div className="absolute top-0 left-0 w-1 h-full bg-slate-700 group-hover:bg-blue-500 transition-colors duration-300"></div>
 
-                                    <div className="flex flex-col md:flex-row md:items-center gap-4 pl-3">
+                                    <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-4 pl-3">
                                         {/* Date Section */}
-                                        <div className="md:w-28 flex-shrink-0 flex flex-col justify-center">
-                                            <div className="text-2xl font-bold font-oswald text-slate-300 group-hover:text-white leading-none">
-                                                {new Date(live.date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replaceAll('/', '.')}
-                                            </div>
-                                            <div className="flex items-center gap-1 mt-2">
-                                                <span className={`text-[10px] w-full text-center font-bold px-1 py-0.5 rounded text-white
+                                        <div className="w-full md:w-28 flex-shrink-0 flex flex-row md:flex-col items-center md:items-start gap-2 md:gap-1 md:justify-start pt-0.5">
+                                            <div className="flex items-center gap-2">
+                                                <div className="text-xl md:text-2xl font-bold font-oswald text-slate-300 group-hover:text-white leading-none">
+                                                    {new Date(live.date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replaceAll('/', '.')}
+                                                </div>
+                                                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded text-white inline-block
                                                     ${live.type === 'FESTIVAL' ? 'bg-purple-600' :
                                                         live.type === 'EVENT' ? 'bg-orange-600' :
                                                             'bg-emerald-600'}`}>
@@ -199,53 +199,66 @@ const LiveList = () => {
                                                             'ONE MAN'}
                                                 </span>
                                             </div>
-                                        </div>
 
-                                        {/* Main Info */}
-                                        <div className="flex-1 min-w-0 border-l border-slate-700/50 md:pl-4">
-                                            <h2 className="text-xl font-bold text-white mb-1 truncate group-hover:text-blue-400 transition-colors">
-                                                {live.tour_name}
-                                            </h2>
-                                            {live.title && live.title !== live.tour_name && (
-                                                <div className="text-blue-200 text-sm font-medium mb-1 flex items-center gap-1">
-                                                    <Tag size={12} /> {live.title}
-                                                </div>
-                                            )}
-                                            {live.special_note && (
-                                                <div className="text-yellow-400 text-base font-bold mb-1">
-                                                    {live.special_note}
-                                                </div>
-                                            )}
-                                            <div className="flex items-center gap-4 mt-2">
-                                                <div className="flex items-center gap-1.5 text-slate-400 text-sm group-hover:text-slate-300">
-                                                    <MapPin size={14} className="text-secondary-color" />
-                                                    <span className="font-medium">{live.venue}</span>
-                                                </div>
-                                                {/* Placeholder for Setlist Count if available in future */}
-                                                {/* <div className="flex items-center gap-1.5 text-slate-500 text-xs">
-                                                    <Music size={12} /> 20 Songs
-                                                </div> */}
-                                            </div>
-                                        </div>
-
-                                        {/* Actions */}
-                                        <div className="flex items-center gap-4 pl-2 md:pl-0 md:border-none border-t border-slate-700/50 pt-3 md:pt-0">
+                                            {/* Mobile Button */}
                                             <button
                                                 onClick={(e) => handleToggleAttendance(e, live.id)}
-                                                className={`px-4 py-1.5 rounded-full text-xs font-bold transition-all duration-200 flex items-center gap-1.5 whitespace-nowrap z-10 relative
+                                                className={`md:hidden ml-auto px-3 py-1 rounded-full text-[10px] font-bold transition-all duration-200 flex items-center gap-1 whitespace-nowrap z-10 relative
                                                     ${isAttended(live.id)
                                                         ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/50 hover:bg-emerald-500/30'
                                                         : 'bg-slate-700 text-slate-300 border border-transparent hover:bg-slate-600'}`}
                                             >
                                                 {isAttended(live.id) ? (
-                                                    <><Check size={12} /> 参戦済み</>
+                                                    <><Check size={10} /> 参戦済み</>
                                                 ) : (
-                                                    <><Plus size={12} /> 参戦記録をつける</>
+                                                    <><Plus size={10} /> 参戦記録</>
+                                                )}
+                                            </button>
+                                        </div>
+
+                                        {/* Main Info */}
+                                        <div className="flex-1 min-w-0 md:border-l border-slate-700/50 md:pl-4">
+                                            <h2 className="text-lg md:text-xl font-bold text-white leading-tight group-hover:text-blue-400 transition-colors" style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                                                {live.tour_name}
+                                            </h2>
+                                            {live.title && live.title !== live.tour_name && (
+                                                <div className="text-blue-200 text-xs font-medium mt-0.5 flex items-center gap-1">
+                                                    <Tag size={10} /> {live.title}
+                                                </div>
+                                            )}
+                                            {live.special_note && (
+                                                <div className="text-yellow-400 text-xs font-bold mt-1 flex items-center gap-1">
+                                                    <span className="bg-yellow-500/10 border border-yellow-500/30 px-1.5 py-0.5 rounded">
+                                                        {live.special_note}
+                                                    </span>
+                                                </div>
+                                            )}
+                                            <div className="flex items-center gap-3 mt-1">
+                                                <div className="flex items-center gap-1 text-slate-400 text-xs group-hover:text-slate-300">
+                                                    <MapPin size={12} className="text-secondary-color" />
+                                                    <span className="font-medium">{live.venue}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        {/* Actions (Desktop Only) */}
+                                        <div className="hidden md:flex items-center justify-start gap-3 pl-0 border-t border-slate-700/50 pt-0 mt-0 md:border-none">
+                                            <button
+                                                onClick={(e) => handleToggleAttendance(e, live.id)}
+                                                className={`px-3 py-1 rounded-full text-[10px] font-bold transition-all duration-200 flex items-center gap-1 whitespace-nowrap z-10 relative
+                                                    ${isAttended(live.id)
+                                                        ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/50 hover:bg-emerald-500/30'
+                                                        : 'bg-slate-700 text-slate-300 border border-transparent hover:bg-slate-600'}`}
+                                            >
+                                                {isAttended(live.id) ? (
+                                                    <><Check size={10} /> 参戦済み</>
+                                                ) : (
+                                                    <><Plus size={10} /> 参戦記録</>
                                                 )}
                                             </button>
 
-                                            <div className="hidden md:flex items-center text-slate-600 group-hover:text-blue-500 transition-colors">
-                                                <ArrowRight size={20} />
+                                            <div className="flex items-center text-slate-600 group-hover:text-blue-500 transition-colors">
+                                                <ArrowRight size={18} />
                                             </div>
                                         </div>
                                     </div>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -136,7 +136,8 @@ const Login = () => {
             </form>
 
             <div style={{ marginTop: '20px', textAlign: 'center', fontSize: '0.9rem', color: '#94a3b8' }}>
-                アカウントをお持ちでないですか？ <Link to="/signup" style={{ color: 'var(--primary-color)', textDecoration: 'none', fontWeight: 'bold' }}>新規登録</Link>
+                アカウントをお持ちでないですか？<br />
+                <Link to="/signup" style={{ color: 'var(--primary-color)', textDecoration: 'none', fontWeight: 'bold', display: 'inline-block', marginTop: '8px' }}>新規登録</Link>
             </div>
         </AuthLayout>
     );

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -185,7 +185,7 @@ function MyPage() {
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
                     <h1 style={{ margin: 0, fontSize: '1.8rem', fontWeight: '800', letterSpacing: '-0.02em', lineHeight: 1.2 }}>
-                        {currentUser?.username ? `${currentUser.username}'s` : 'My'}{' '}
+                        {currentUser?.username ? `${currentUser.username}'s` : 'My'}<br />
                         <span className="text-gold" style={{ textShadow: '0 0 15px rgba(251, 191, 36, 0.2)' }}>UVER</span> Records
                     </h1>
                     <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '12px', marginTop: '12px' }}>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -211,24 +211,19 @@ function MyPage() {
             {stats.totalLives > 0 ? (
                 <>
                     {/* Summary Cards */}
-                    <div style={{
-                        display: 'grid',
-                        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-                        gap: '30px',
-                        marginBottom: '40px'
-                    }}>
+                    <div className="stats-grid">
                         <div className="stat-card" onClick={handleTotalLivesClick} style={{ cursor: 'pointer' }}>
-                            <div className="stat-icon"><Calendar size={24} /></div>
+                            <div className="stat-icon"><Calendar size={20} /></div>
                             <div className="stat-label">通算参戦数</div>
                             <div className="stat-value">{stats.totalLives}</div>
                         </div>
                         <div className="stat-card" onClick={handleCollectedSongsClick} style={{ cursor: 'pointer' }}>
-                            <div className="stat-icon"><Music size={24} /></div>
-                            <div className="stat-label">収集した楽曲数</div>
+                            <div className="stat-icon"><Music size={20} /></div>
+                            <div className="stat-label" style={{ whiteSpace: 'nowrap' }}>収集した楽曲数</div>
                             <div className="stat-value">{stats.uniqueSongs}</div>
                         </div>
                         {stats.firstLive && (
-                            <Link to={`/live/${stats.firstLive.id}`} state={{ from: location.pathname }} className="stat-card group" style={{ gridColumn: 'span 2', background: 'linear-gradient(135deg, rgba(30, 41, 59, 0.8) 0%, rgba(15, 23, 42, 0.9) 100%)', borderColor: '#d4af37', textDecoration: 'none' }}>
+                            <Link to={`/live/${stats.firstLive.id}`} state={{ from: location.pathname }} className="stat-card group" style={{ gridColumn: '1 / -1', background: 'linear-gradient(135deg, rgba(30, 41, 59, 0.8) 0%, rgba(15, 23, 42, 0.9) 100%)', borderColor: '#d4af37', textDecoration: 'none' }}>
                                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                                     <div>
                                         <div className="stat-icon" style={{ color: '#d4af37', marginBottom: '5px' }}><MapPin size={24} /></div>
@@ -542,6 +537,13 @@ function MyPage() {
                 }
                 .modal-live-item:hover { background: rgba(255,255,255,0.03); }
                 .back-btn { background: none; border: none; color: var(--primary-color); cursor: pointer; padding: 0; margin-bottom: 20px; }
+
+                .stats-grid {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: 30px;
+                    margin-bottom: 40px;
+                }
 
                 @media (max-width: 640px) {
                     .profile-header-section { flex-direction: column; text-align: center; gap: 20px; }

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -224,7 +224,8 @@ const Signup = () => {
             </form>
 
             <div style={{ marginTop: '20px', textAlign: 'center', fontSize: '0.9rem', color: '#94a3b8' }}>
-                すでにアカウントをお持ちですか？ <Link to="/login" style={{ color: 'var(--primary-color)', textDecoration: 'none', fontWeight: 'bold' }}>ログイン</Link>
+                すでにアカウントをお持ちですか？<br />
+                <Link to="/login" style={{ color: 'var(--primary-color)', textDecoration: 'none', fontWeight: 'bold', display: 'inline-block', marginTop: '8px' }}>ログイン</Link>
             </div>
         </AuthLayout>
     );


### PR DESCRIPTION
参戦履歴リストのPCレイアウトを整理（検索ボックスを広げ、フィルター/ソートを右側に配置）
MyPageタイトルの名前の後で改行を入れるように変更（モバイルでの見切れ防止）
Dashboardの「Top Songs」タイトルから「(Top 10)」の表記を削除