### PR TITLE
fix: 通知遷移先URLのパス修正 (/lives -> /live)

### DIFF
--- a/server/utils/pushNotification.js
+++ b/server/utils/pushNotification.js
@@ -107,7 +107,7 @@ async function notifyNewLive(live) {
         icon: '/icons/icon-192x192.png',
         badge: '/icons/icon-192x192.png',
         data: {
-            url: `/lives/${live.id}`,
+            url: `/live/${live.id}`,
             type: 'new_live'
         }
     };


### PR DESCRIPTION
[通知遷移先URLのパス修正 (/lives -> /live)](https://github.com/hayaryoo519/uver-setlist-app/commit/80c95cf6ada8ff9406a40f23358a92d02df48211)