### PR TITLE
モバイルレスポンシブ改善: Dashboard・PredictionRanking

### DIFF
--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -26,20 +26,91 @@
   - `predictions`: 予想の基本情報（ユーザー、対象ライブ、タイトル等）を格納。
   - `prediction_songs`: 各予想に含まれる楽曲と演奏順 (`order_index`) を紐付け。
   - `prediction_likes`: ユーザーからの「いいね」を管理（ユニーク制約による重複防止）。
+  - `prediction_scores`: スコア採点結果（後述）。
 - **機能一覧**:
   - **予想ポータル**: 受付中のライブ一覧と、自分の予想履歴を確認できる。
-  - **予想作成**: 
+  - **予想作成**:
     - ドラッグ＆ドロップによる直感的な曲順操作。
-    - 全楽曲リストから選択可能。
+    - アルバム・シングル収録曲のみ選択可能（ディスコグラフィ連動）。
+    - **受付締め切り**: ライブ当日 JST 0:00 をもって自動終了。サーバーサイドで判定。
+    - 2026-05-01 よりも前の公演は予想セクション自体を非表示。
   - **ランキング/共有**:
-    - 各ライブごとの「みんなの予想」を人気順（いいね数）・新着順で閲覧。
-    - 各予想詳細ページから X (Twitter) へのシェア機能。
+    - 各ライブごとの「みんなの予想」を人気順（いいね数）・新着順・**スコア順**で閲覧。
+    - スコア算出済みのライブでは「スコア順」タブが表示される。
+    - 各予想詳細ページから X (Twitter) へのシェア機能（スコアありの場合は結果をツイートに自動挿入）。
   - **インタラクション**:
     - 他のユーザーの予想に対する「いいね！」機能。
 - **UI/UXルール**:
   - ボタン等のアクション要素には「セトリ予想」と表記。
   - タイトルや説明文などの詳細要素には「セットリスト予想」と表記。
   - ダッシュボードの次回ライブには「セトリ予想受付中 🔥」バッジを表示し、導線を強化。
+
+### 2-1. スコアリング仕様
+
+ライブのセットリストが確定（`setlist_status = 'NORMAL'`）した後、全予想を自動採点する。
+
+**スコア計算式**:
+
+```
+denominator    = max(actual_count, predicted_count)
+match_score    = round((matched_count    / denominator) × 70, 2)   # 最大70pt
+position_score = round((position_matched / denominator) × 20, 2)   # 最大20pt
+streak_bonus   = round(min(max_streak × 2, 10), 2)                 # 最大10pt
+total_score    = match_score + position_score + streak_bonus        # 最大100pt
+```
+
+| 要素 | 配点 | 判定基準 |
+|---|---|---|
+| 一致スコア | 70pt | 予想曲が実際のセトリに含まれていた割合 |
+| 順番スコア | 20pt | 同じ位置（順番）で一致した曲の割合 |
+| 連続ボーナス | 10pt | 予想内での最長連続一致 × 2（上限10pt） |
+
+> `denominator` に `max` を使うことで、曲数を少なく予想して的中率を上げる行為を防止。
+
+**スコアラベル**:
+
+| スコア | ラベル |
+|---|---|
+| 90〜100pt | 神予想 |
+| 75〜89pt | 優秀 |
+| 50〜74pt | 合格 |
+| 25〜49pt | 惜しい |
+| 0〜24pt | 次回に期待 |
+
+**スコア計算のトリガー**:
+
+| タイミング | 処理 |
+|---|---|
+| `PUT /api/lives/:id/setlist`（管理者） | `setlist_status = 'NORMAL'` → バックグラウンドで全予想を自動再計算 |
+| `POST /api/lives/:id/import-setlist`（管理者） | 同上 |
+| `POST /api/lives/:id/recalculate-scores`（管理者） | 手動で全予想を再計算（べき等） |
+
+**DBテーブル (`prediction_scores`)**:
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `prediction_id` | INTEGER UNIQUE | 予想ID（1予想につき1スコア） |
+| `live_id` | INTEGER | ライブID |
+| `user_id` | INTEGER | ユーザーID |
+| `predicted_count` | INTEGER | 予想曲数 |
+| `actual_count` | INTEGER | 実際の曲数 |
+| `matched_count` | INTEGER | 一致曲数 |
+| `position_matched` | INTEGER | 順番まで一致した曲数 |
+| `max_streak` | INTEGER | 最長連続一致数 |
+| `match_score` | NUMERIC(5,2) | 一致スコア |
+| `position_score` | NUMERIC(5,2) | 順番スコア |
+| `streak_bonus` | NUMERIC(5,2) | 連続ボーナス |
+| `total_score` | NUMERIC(5,2) | 合計スコア |
+| `rank` | INTEGER | 順位（将来用、現在は NULL） |
+
+**スコア関連APIエンドポイント**:
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| GET | `/api/predictions?sort=score` | 任意 | スコア降順で予想一覧を返す |
+| GET | `/api/predictions/:id` | 任意 | スコア内訳を含む予想詳細 |
+| POST | `/api/predictions` | 必須 | 締め切りチェック付きで予想を投稿 |
+| POST | `/api/lives/:id/recalculate-scores` | 管理者 | 指定ライブの全予想スコアを再計算 |
 
 ## 3. フォロー機能 & ユーザープロフィール
 

--- a/server/migrations/014_prediction_scores.sql
+++ b/server/migrations/014_prediction_scores.sql
@@ -1,0 +1,22 @@
+-- セトリ予想スコアリングテーブル
+CREATE TABLE IF NOT EXISTS prediction_scores (
+    id               SERIAL PRIMARY KEY,
+    prediction_id    INTEGER NOT NULL REFERENCES predictions(id) ON DELETE CASCADE,
+    live_id          INTEGER NOT NULL REFERENCES lives(id) ON DELETE CASCADE,
+    user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    predicted_count  INTEGER         NOT NULL DEFAULT 0,
+    actual_count     INTEGER         NOT NULL DEFAULT 0,
+    matched_count    INTEGER         NOT NULL DEFAULT 0,
+    position_matched INTEGER         NOT NULL DEFAULT 0,
+    max_streak       INTEGER         NOT NULL DEFAULT 0,
+    match_score      NUMERIC(5,2)    NOT NULL DEFAULT 0,
+    position_score   NUMERIC(5,2)    NOT NULL DEFAULT 0,
+    streak_bonus     NUMERIC(5,2)    NOT NULL DEFAULT 0,
+    total_score      NUMERIC(5,2)    NOT NULL DEFAULT 0,
+    rank             INTEGER,
+    calculated_at    TIMESTAMP       DEFAULT NOW(),
+    CONSTRAINT prediction_scores_prediction_id_key UNIQUE (prediction_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prediction_scores_live_id ON prediction_scores(live_id, total_score DESC);
+CREATE INDEX IF NOT EXISTS idx_prediction_scores_user_id ON prediction_scores(user_id);

--- a/server/routes/lives.js
+++ b/server/routes/lives.js
@@ -3,6 +3,7 @@ const db = require('../db');
 const { authorize, adminCheck } = require('../middleware/authorization');
 const { normalizeVenueName } = require('../utils/songTranslations');
 const { notifyNewLive } = require('../utils/pushNotification');
+const { recalculateScoresForLive } = require('../services/scoreCalculator');
 
 // GET All Lives with Advanced Filters
 router.get('/', async (req, res) => {
@@ -316,6 +317,18 @@ router.post('/batch-delete', authorize, adminCheck, async (req, res) => {
     } catch (err) {
         console.error("Batch delete error:", err.message);
         res.status(500).send("Server Error");
+    }
+});
+
+// セトリ予想スコアを一括再計算 (Admin only)
+router.post('/:id/recalculate-scores', authorize, adminCheck, async (req, res) => {
+    try {
+        const { id } = req.params;
+        const result = await recalculateScoresForLive(Number(id));
+        res.json(result);
+    } catch (err) {
+        console.error('recalculate-scores error:', err.message);
+        res.status(500).json({ message: err.message });
     }
 });
 

--- a/server/routes/lives.js
+++ b/server/routes/lives.js
@@ -229,7 +229,6 @@ router.put('/:id/setlist', authorize, adminCheck, async (req, res) => {
         const { id } = req.params;
         const { songs } = req.body; // Expect array of song_ids
 
-        // Transaction mostly
         await db.query("BEGIN");
 
         // 1. Delete existing setlist
@@ -247,7 +246,19 @@ router.put('/:id/setlist', authorize, adminCheck, async (req, res) => {
             }
         }
 
+        // 3. setlist_status を NORMAL に更新
+        const newStatus = songs && songs.length > 0 ? 'NORMAL' : 'UNKNOWN_SETLIST';
+        await db.query("UPDATE lives SET setlist_status = $1 WHERE id = $2", [newStatus, id]);
+
         await db.query("COMMIT");
+
+        // 4. NORMAL になった場合はスコアを非同期で再計算（レスポンスは待たない）
+        if (newStatus === 'NORMAL') {
+            recalculateScoresForLive(Number(id)).catch(err =>
+                console.error(`auto recalculate scores for live ${id}:`, err.message)
+            );
+        }
+
         res.json({ message: "Setlist updated" });
     } catch (err) {
         await db.query("ROLLBACK");
@@ -292,7 +303,16 @@ router.post('/:id/import-setlist', authorize, adminCheck, async (req, res) => {
             );
         }
 
+        // setlist_status を NORMAL に更新
+        await db.query("UPDATE lives SET setlist_status = 'NORMAL' WHERE id = $1", [id]);
+
         await db.query("COMMIT");
+
+        // スコアを非同期で再計算
+        recalculateScoresForLive(Number(id)).catch(err =>
+            console.error(`auto recalculate scores for live ${id}:`, err.message)
+        );
+
         res.json({ message: "Setlist imported successfully", count: songs.length });
 
     } catch (err) {

--- a/server/routes/predictions.js
+++ b/server/routes/predictions.js
@@ -53,17 +53,20 @@ router.get('/', async (req, res) => {
         }
 
         let query = `
-            SELECT 
-                p.*, 
+            SELECT
+                p.*,
                 u.username,
                 li.tour_name, li.venue, li.date as live_date,
                 COUNT(DISTINCT pl.user_id) as like_count,
                 EXISTS(SELECT 1 FROM prediction_likes WHERE prediction_id = p.id AND user_id = $1) as is_liked,
-                (p.user_id = $1) as is_mine
+                (p.user_id = $1) as is_mine,
+                ps.total_score, ps.match_score, ps.position_score, ps.streak_bonus,
+                ps.matched_count, ps.predicted_count, ps.actual_count, ps.rank
             FROM predictions p
             JOIN users u ON p.user_id = u.id
             JOIN lives li ON p.live_id = li.id
             LEFT JOIN prediction_likes pl ON p.id = pl.prediction_id
+            LEFT JOIN prediction_scores ps ON ps.prediction_id = p.id
         `;
 
         const params = [currentUserId];
@@ -87,7 +90,7 @@ router.get('/', async (req, res) => {
             query += ` WHERE ` + conditions.join(' AND ');
         }
 
-        query += ` GROUP BY p.id, u.username, li.id `;
+        query += ` GROUP BY p.id, u.username, li.id, ps.total_score, ps.match_score, ps.position_score, ps.streak_bonus, ps.matched_count, ps.predicted_count, ps.actual_count, ps.rank `;
 
         if (sort === 'new') {
             query += ` ORDER BY p.created_at DESC `;
@@ -112,19 +115,22 @@ router.get('/:id', async (req, res) => {
 
         // Get basic info
         const predResult = await db.query(`
-            SELECT 
-                p.*, 
+            SELECT
+                p.*,
                 u.username,
-                COUNT(DISTINCT l.user_id) as like_count,
+                COUNT(DISTINCT pl.user_id) as like_count,
                 EXISTS(SELECT 1 FROM prediction_likes WHERE prediction_id = p.id AND user_id = $1) as is_liked,
                 (p.user_id = $1) as is_mine,
-                li.tour_name, li.venue, li.date as live_date
+                li.tour_name, li.venue, li.date as live_date,
+                ps.total_score, ps.match_score, ps.position_score, ps.streak_bonus,
+                ps.matched_count, ps.predicted_count, ps.actual_count, ps.rank
             FROM predictions p
             JOIN users u ON p.user_id = u.id
-            LEFT JOIN prediction_likes l ON p.id = l.prediction_id
+            LEFT JOIN prediction_likes pl ON p.id = pl.prediction_id
             LEFT JOIN lives li ON p.live_id = li.id
+            LEFT JOIN prediction_scores ps ON ps.prediction_id = p.id
             WHERE p.id = $2
-            GROUP BY p.id, u.username, li.id
+            GROUP BY p.id, u.username, li.id, ps.total_score, ps.match_score, ps.position_score, ps.streak_bonus, ps.matched_count, ps.predicted_count, ps.actual_count, ps.rank
         `, [currentUserId, id]);
 
         if (predResult.rows.length === 0) {
@@ -159,6 +165,18 @@ router.post('/', authorize, async (req, res) => {
 
         if (!songs || !Array.isArray(songs) || songs.length === 0) {
             return res.status(400).json({ message: 'At least one song is required' });
+        }
+
+        // ライブ日程を取得して締め切りチェック（ライブ当日 JST 0:00 以降は投稿不可）
+        const liveCheck = await db.query('SELECT date FROM lives WHERE id = $1', [live_id]);
+        if (liveCheck.rows.length === 0) {
+            return res.status(404).json({ message: 'Live not found' });
+        }
+        const liveDate = liveCheck.rows[0].date; // YYYY-MM-DD
+        const nowJST = new Date(Date.now() + 9 * 60 * 60 * 1000);
+        const todayJST = nowJST.toISOString().slice(0, 10);
+        if (todayJST >= liveDate) {
+            return res.status(403).json({ message: '予想の受付は終了しました（ライブ当日の 0:00 JST をもって締め切り）' });
         }
 
         await client.query('BEGIN');

--- a/server/routes/predictions.js
+++ b/server/routes/predictions.js
@@ -94,6 +94,8 @@ router.get('/', async (req, res) => {
 
         if (sort === 'new') {
             query += ` ORDER BY p.created_at DESC `;
+        } else if (sort === 'score') {
+            query += ` ORDER BY ps.total_score DESC NULLS LAST, like_count DESC `;
         } else {
             // Default: popular (like_count)
             query += ` ORDER BY like_count DESC, p.created_at DESC `;

--- a/server/services/scoreCalculator.js
+++ b/server/services/scoreCalculator.js
@@ -1,0 +1,181 @@
+const db = require('../db');
+
+/**
+ * 予想セトリのスコアを計算する
+ *
+ * スコア式:
+ *   denominator = max(actual_count, predicted_count)
+ *   match_score    = round((matched_count / denominator) × 70, 2)
+ *   position_score = round((position_matched / denominator) × 20, 2)
+ *   streak_bonus   = round(min(max_streak × 2, 10), 2)
+ *   total_score    = match_score + position_score + streak_bonus
+ */
+
+/**
+ * 最大連続一致数を求める
+ * @param {string[]} predicted - 予想曲順（normalized_title）
+ * @param {string[]} actual    - 実際の曲順（normalized_title）
+ */
+function calcMaxStreak(predicted, actual) {
+    const actualSet = new Set(actual);
+    let maxStreak = 0;
+    let currentStreak = 0;
+
+    for (const song of predicted) {
+        if (actualSet.has(song)) {
+            currentStreak++;
+            maxStreak = Math.max(maxStreak, currentStreak);
+        } else {
+            currentStreak = 0;
+        }
+    }
+    return maxStreak;
+}
+
+/**
+ * 1件の予想に対してスコアを計算し prediction_scores へ UPSERT する
+ * @param {number} predictionId
+ * @returns {object} 算出結果
+ */
+async function calculateScore(predictionId) {
+    // 予想データ取得
+    const predRes = await db.query(
+        `SELECT p.id, p.live_id, p.user_id, p.songs
+         FROM predictions p
+         WHERE p.id = $1`,
+        [predictionId]
+    );
+    if (predRes.rows.length === 0) throw new Error(`prediction ${predictionId} not found`);
+
+    const prediction = predRes.rows[0];
+    const predictedSongs = Array.isArray(prediction.songs) ? prediction.songs : [];
+
+    // 実際のセトリ取得（setlist_status = 'NORMAL' のライブ）
+    const liveRes = await db.query(
+        `SELECT l.id, l.setlist_status,
+                COALESCE(
+                    (SELECT array_agg(s.normalized_title ORDER BY ls.position)
+                     FROM live_songs ls
+                     JOIN songs s ON s.id = ls.song_id
+                     WHERE ls.live_id = l.id),
+                    '{}'::text[]
+                ) AS actual_songs
+         FROM lives l
+         WHERE l.id = $1`,
+        [prediction.live_id]
+    );
+    if (liveRes.rows.length === 0) throw new Error(`live ${prediction.live_id} not found`);
+
+    const live = liveRes.rows[0];
+    if (live.setlist_status !== 'NORMAL') {
+        throw new Error(`live ${prediction.live_id} is not NORMAL (status: ${live.setlist_status})`);
+    }
+
+    const actualSongs = live.actual_songs || [];
+
+    // 予想曲リストをnormalized_titleへ変換
+    const predictedTitles = await normalizePredictedSongs(predictedSongs);
+    const actualTitles = actualSongs.map(s => s).filter(Boolean);
+
+    // マッチ数・順番一致数・最大連続数を算出
+    const actualSet = new Set(actualTitles);
+    const matchedCount = predictedTitles.filter(t => actualSet.has(t)).length;
+
+    const minLen = Math.min(predictedTitles.length, actualTitles.length);
+    let positionMatched = 0;
+    for (let i = 0; i < minLen; i++) {
+        if (predictedTitles[i] === actualTitles[i]) positionMatched++;
+    }
+
+    const maxStreak = calcMaxStreak(predictedTitles, actualTitles);
+
+    const predictedCount = predictedTitles.length;
+    const actualCount = actualTitles.length;
+    const denominator = Math.max(actualCount, predictedCount);
+
+    let matchScore = 0, positionScore = 0, streakBonus = 0, totalScore = 0;
+    if (denominator > 0) {
+        matchScore    = Math.round((matchedCount / denominator) * 70 * 100) / 100;
+        positionScore = Math.round((positionMatched / denominator) * 20 * 100) / 100;
+        streakBonus   = Math.round(Math.min(maxStreak * 2, 10) * 100) / 100;
+        totalScore    = Math.round((matchScore + positionScore + streakBonus) * 100) / 100;
+    }
+
+    // UPSERT
+    await db.query(
+        `INSERT INTO prediction_scores
+            (prediction_id, live_id, user_id,
+             predicted_count, actual_count, matched_count,
+             position_matched, max_streak,
+             match_score, position_score, streak_bonus, total_score,
+             calculated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12, NOW())
+         ON CONFLICT (prediction_id) DO UPDATE SET
+             predicted_count  = EXCLUDED.predicted_count,
+             actual_count     = EXCLUDED.actual_count,
+             matched_count    = EXCLUDED.matched_count,
+             position_matched = EXCLUDED.position_matched,
+             max_streak       = EXCLUDED.max_streak,
+             match_score      = EXCLUDED.match_score,
+             position_score   = EXCLUDED.position_score,
+             streak_bonus     = EXCLUDED.streak_bonus,
+             total_score      = EXCLUDED.total_score,
+             calculated_at    = NOW()`,
+        [
+            predictionId, prediction.live_id, prediction.user_id,
+            predictedCount, actualCount, matchedCount,
+            positionMatched, maxStreak,
+            matchScore, positionScore, streakBonus, totalScore
+        ]
+    );
+
+    return { predictionId, matchScore, positionScore, streakBonus, totalScore, matchedCount, predictedCount, actualCount };
+}
+
+/**
+ * 予想曲リスト（song_id 配列または {song_id} オブジェクト配列）を
+ * normalized_title 配列に変換する
+ */
+async function normalizePredictedSongs(songs) {
+    if (!songs || songs.length === 0) return [];
+
+    const songIds = songs.map(s => (typeof s === 'object' ? s.song_id || s.id : s)).filter(Boolean);
+    if (songIds.length === 0) return [];
+
+    const res = await db.query(
+        `SELECT id, normalized_title FROM songs WHERE id = ANY($1::int[])`,
+        [songIds]
+    );
+    const map = new Map(res.rows.map(r => [r.id, r.normalized_title]));
+
+    return songIds.map(id => map.get(id)).filter(Boolean);
+}
+
+/**
+ * 指定ライブの全予想スコアを一括再計算する
+ * @param {number} liveId
+ * @returns {{ success: number, failed: number, errors: string[] }}
+ */
+async function recalculateScoresForLive(liveId) {
+    const predsRes = await db.query(
+        `SELECT id FROM predictions WHERE live_id = $1`,
+        [liveId]
+    );
+
+    let success = 0, failed = 0;
+    const errors = [];
+
+    for (const row of predsRes.rows) {
+        try {
+            await calculateScore(row.id);
+            success++;
+        } catch (err) {
+            failed++;
+            errors.push(`prediction ${row.id}: ${err.message}`);
+        }
+    }
+
+    return { success, failed, errors };
+}
+
+module.exports = { calculateScore, recalculateScoresForLive };

--- a/server/services/scoreCalculator.js
+++ b/server/services/scoreCalculator.js
@@ -54,10 +54,10 @@ async function calculateScore(predictionId) {
     const liveRes = await db.query(
         `SELECT l.id, l.setlist_status,
                 COALESCE(
-                    (SELECT array_agg(s.normalized_title ORDER BY ls.position)
-                     FROM live_songs ls
-                     JOIN songs s ON s.id = ls.song_id
-                     WHERE ls.live_id = l.id),
+                    (SELECT array_agg(s.normalized_title ORDER BY sl.position)
+                     FROM setlists sl
+                     JOIN songs s ON s.id = sl.song_id
+                     WHERE sl.live_id = l.id),
                     '{}'::text[]
                 ) AS actual_songs
          FROM lives l

--- a/src/components/Dashboard/LatestLiveCard.jsx
+++ b/src/components/Dashboard/LatestLiveCard.jsx
@@ -15,8 +15,6 @@ export const LatestLiveCard = ({ live }) => {
             position: 'relative',
             overflow: 'hidden'
         }}>
-
-
             <div style={{ position: 'relative', zIndex: 1 }}>
                 <div style={{
                     textTransform: 'uppercase',
@@ -33,8 +31,7 @@ export const LatestLiveCard = ({ live }) => {
                     LATEST LIVE
                 </div>
 
-                <h3 style={{
-                    fontSize: '1.8rem',
+                <h3 className="latest-live-title" style={{
                     margin: '0 0 10px 0',
                     lineHeight: '1.2',
                     fontWeight: '800'
@@ -60,13 +57,14 @@ export const LatestLiveCard = ({ live }) => {
                     </div>
                 </div>
 
-                <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+                <div className="latest-live-buttons">
                     <Link
                         to={`/live/${live.id}`}
                         state={{ from: location.pathname }}
                         style={{
                             display: 'inline-flex',
                             alignItems: 'center',
+                            justifyContent: 'center',
                             gap: '8px',
                             background: '#fbbf24',
                             color: '#000',
@@ -87,9 +85,10 @@ export const LatestLiveCard = ({ live }) => {
                         style={{
                             display: 'inline-flex',
                             alignItems: 'center',
+                            justifyContent: 'center',
                             gap: '8px',
-                            background: 'rgba(255, 255, 255, 0.3)', /* さらに明るく */
-                            border: '1px solid rgba(255, 255, 255, 0.6)', /* 枠線を強調 */
+                            background: 'rgba(255, 255, 255, 0.3)',
+                            border: '1px solid rgba(255, 255, 255, 0.6)',
                             color: '#fff',
                             padding: '12px 24px',
                             borderRadius: '50px',
@@ -102,9 +101,28 @@ export const LatestLiveCard = ({ live }) => {
                     >
                         みんなのセトリ予想を見る
                     </Link>
-
                 </div>
             </div>
+
+            <style>{`
+                .latest-live-title {
+                    font-size: clamp(1.3rem, 4vw, 1.8rem);
+                }
+                .latest-live-buttons {
+                    display: flex;
+                    gap: 12px;
+                    flex-wrap: wrap;
+                }
+                @media (max-width: 480px) {
+                    .latest-live-buttons {
+                        flex-direction: column;
+                    }
+                    .latest-live-buttons a {
+                        width: 100%;
+                        box-sizing: border-box;
+                    }
+                }
+            `}</style>
         </div>
     );
 };

--- a/src/components/Dashboard/UpcomingLives.jsx
+++ b/src/components/Dashboard/UpcomingLives.jsx
@@ -18,7 +18,7 @@ export const UpcomingLives = ({ lives }) => {
             </h2>
 
 
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '20px' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(300px, 100%), 1fr))', gap: '20px' }}>
                 {nextLives.map((live, index) => (
                     <div
                         key={index}

--- a/src/pages/LiveDetail.tsx
+++ b/src/pages/LiveDetail.tsx
@@ -83,7 +83,7 @@ function LiveDetail() {
                 title={`${mainTitle} (${new Date(live.date).toLocaleDateString()})`}
                 description={`UVERworld ${mainTitle} @ ${live.venue} Setlist and Live Report.`}
             />
-            
+
             <div className="max-w-3xl mx-auto px-6">
                 <div className="flex justify-between items-center mb-10">
                     <button
@@ -95,7 +95,7 @@ function LiveDetail() {
                         </div>
                         <span className="text-sm font-medium">{backLabel}</span>
                     </button>
-                    
+
                     <button
                         onClick={handleToggleAttendance}
                         disabled={attendanceLoading}
@@ -215,14 +215,22 @@ function LiveDetail() {
                 {/* セトリ予想セクション */}
                 <div className="mt-12">
                     {(() => {
-                        // 過去のライブかどうか判定（セトリがあるか、日付が過去か）
-                        const isPastLive = setlist.length > 0 || new Date(live.date) < new Date(new Date().setHours(0,0,0,0));
+                        const liveDate = new Date(live.date);
+                        const PREDICTION_START_DATE = new Date('2026-05-01');
                         
+                        // 予想機能リリース（2026/05/01）より前のライブは非表示
+                        if (liveDate < PREDICTION_START_DATE) {
+                            return null;
+                        }
+
+                        // 過去のライブかどうか判定（セトリがあるか、日付が過去か）
+                        const isPastLive = setlist.length > 0 || liveDate < new Date(new Date().setHours(0, 0, 0, 0));
+
                         // 過去のライブで、予想が1件もない場合は非表示にする
                         if (isPastLive && (live.prediction_count ?? 0) === 0) {
                             return null;
                         }
-                        
+
                         return (
                             <Link
                                 to={`/predictions?live_id=${liveId}`}
@@ -232,7 +240,7 @@ function LiveDetail() {
                                 <div className="absolute top-0 right-0 p-6 opacity-10 group-hover:opacity-20 transition-opacity">
                                     <Sparkles size={120} className="text-blue-400" />
                                 </div>
-                                
+
                                 <div className="relative z-10 flex flex-col md:flex-row md:items-center justify-between gap-6">
                                     <div>
                                         <div className="flex items-center gap-2 mb-3">
@@ -243,22 +251,12 @@ function LiveDetail() {
                                         </div>
                                         <h3 className="text-2xl font-bold text-white mb-2 group-hover:text-blue-300 transition-colors">
                                             {isPastLive ? "みんなのセトリ予想ランキング" : "このライブのセトリを予想しよう！"}
-                                         </h3>
+                                        </h3>
                                         <p className="text-slate-400 text-sm max-w-md">
-                                            {isPastLive 
+                                            {isPastLive
                                                 ? "ライブ開催前に投稿された、みんなのセトリ予想結果を見てみましょう！"
                                                 : "みんなの予想ランキングをチェックしたり、自分だけの最強のセットリストを投稿してシェアしましょう。"}
                                         </p>
-                                    </div>
-                                    
-                                    <div className="flex items-center gap-4">
-                                        <div className="text-right hidden md:block">
-                                            <div className="text-xs font-bold text-slate-500 mb-1 uppercase tracking-tighter">ランキングを見る</div>
-                                            <div className="text-white font-black text-xl">みんなの予想 &rarr;</div>
-                                        </div>
-                                        <div className="w-12 h-12 rounded-full bg-blue-600 text-white flex items-center justify-center shadow-lg shadow-blue-900/40 group-hover:scale-110 transition-transform">
-                                            <Plus size={24} />
-                                        </div>
                                     </div>
                                 </div>
                             </Link>
@@ -266,15 +264,14 @@ function LiveDetail() {
                     })()}
                 </div>
 
-
                 <div className="mt-16 text-center">
                     <p className="text-slate-500 text-sm mb-6 max-w-sm mx-auto leading-relaxed">
                         セットリストやライブ情報に誤りがある場合は、こちらからお知らせください。
                     </p>
                     <button
                         className={`inline-flex items-center gap-3 px-8 py-4 rounded-full text-sm font-black tracking-widest transition-all duration-300
-                            ${!currentUser 
-                                ? 'bg-slate-800 text-slate-500 border border-slate-700' 
+                            ${!currentUser
+                                ? 'bg-slate-800 text-slate-500 border border-slate-700'
                                 : 'bg-white text-black hover:bg-blue-500 hover:text-white shadow-xl shadow-white/5'}`}
                         onClick={handleCorrectionClick}
                     >

--- a/src/pages/PredictionRanking.tsx
+++ b/src/pages/PredictionRanking.tsx
@@ -107,16 +107,16 @@ const PredictionRanking = () => {
                             </h2>
                         </div>
 
-                        <div className="flex bg-slate-800/50 p-1 rounded-xl border border-slate-700 w-fit mb-6">
+                        <div className="flex bg-slate-800/50 p-1 rounded-xl border border-slate-700 w-full sm:w-fit mb-6">
                             <button
                                 onClick={() => setPortalTab('upcoming')}
-                                className={`px-6 py-2 rounded-lg text-sm font-bold transition-all ${portalTab === 'upcoming' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
+                                className={`flex-1 sm:flex-none px-6 py-2 rounded-lg text-sm font-bold transition-all ${portalTab === 'upcoming' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
                             >
                                 受付中のライブ
                             </button>
                             <button
                                 onClick={() => setPortalTab('mine')}
-                                className={`px-6 py-2 rounded-lg text-sm font-bold transition-all ${portalTab === 'mine' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
+                                className={`flex-1 sm:flex-none px-6 py-2 rounded-lg text-sm font-bold transition-all ${portalTab === 'mine' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
                             >
                                 自分の予想一覧
                             </button>
@@ -162,17 +162,17 @@ const PredictionRanking = () => {
                                                 </div>
                                             </div>
 
-                                            <div className="flex flex-col sm:flex-row gap-3">
+                                            <div className="flex gap-2">
                                                 <Link
                                                     to={`/predictions/new?live_id=${live.id}`}
-                                                    className="bg-blue-600 hover:bg-blue-500 text-white font-bold px-6 py-3 rounded-xl flex items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-blue-900/40"
+                                                    className="flex-1 bg-blue-600 hover:bg-blue-500 text-white font-bold px-4 py-3 rounded-xl flex items-center justify-center gap-2 transition-all hover:shadow-lg hover:shadow-blue-900/40"
                                                 >
                                                     <Plus size={18} />
                                                     予想する
                                                 </Link>
                                                 <Link
                                                     to={`/predictions?live_id=${live.id}`}
-                                                    className="bg-slate-800 hover:bg-slate-700 text-white font-bold px-6 py-3 rounded-xl border border-slate-700 flex items-center justify-center gap-2 transition-all"
+                                                    className="flex-1 bg-slate-800 hover:bg-slate-700 text-white font-bold px-4 py-3 rounded-xl border border-slate-700 flex items-center justify-center gap-2 transition-all"
                                                 >
                                                     <Eye size={18} />
                                                     みんなの予想
@@ -312,37 +312,47 @@ const PredictionRanking = () => {
                         </div>
 
                         {/* 投稿ボタン & ソートタブ */}
-                        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
-                            <div className="flex bg-slate-800/50 p-1 rounded-xl border border-slate-700 w-fit">
-                                <button
-                                    onClick={() => setSortBy('popular')}
-                                    className={`px-6 py-2 rounded-lg text-sm font-bold transition-all ${sortBy === 'popular' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
-                                >
-                                    人気順
-                                </button>
-                                <button
-                                    onClick={() => setSortBy('new')}
-                                    className={`px-6 py-2 rounded-lg text-sm font-bold transition-all ${sortBy === 'new' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
-                                >
-                                    新着順
-                                </button>
-                                {hasScores && (
+                        <div className="flex flex-col gap-3 mb-8">
+                            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                                <div className="flex bg-slate-800/50 p-1 rounded-xl border border-slate-700 w-full sm:w-fit">
                                     <button
-                                        onClick={() => setSortBy('score')}
-                                        className={`px-6 py-2 rounded-lg text-sm font-bold transition-all flex items-center gap-1.5 ${sortBy === 'score' ? 'bg-yellow-500 text-black shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
+                                        onClick={() => setSortBy('popular')}
+                                        className={`flex-1 sm:flex-none px-4 sm:px-6 py-2 rounded-lg text-sm font-bold transition-all ${sortBy === 'popular' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
                                     >
-                                        <Trophy size={14} />
-                                        スコア順
+                                        人気順
                                     </button>
-                                )}
+                                    <button
+                                        onClick={() => setSortBy('new')}
+                                        className={`flex-1 sm:flex-none px-4 sm:px-6 py-2 rounded-lg text-sm font-bold transition-all ${sortBy === 'new' ? 'bg-blue-600 text-white shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
+                                    >
+                                        新着順
+                                    </button>
+                                    {hasScores && (
+                                        <button
+                                            onClick={() => setSortBy('score')}
+                                            className={`flex-1 sm:flex-none px-4 sm:px-6 py-2 rounded-lg text-sm font-bold transition-all flex items-center justify-center gap-1.5 ${sortBy === 'score' ? 'bg-yellow-500 text-black shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
+                                        >
+                                            <Trophy size={14} />
+                                            スコア順
+                                        </button>
+                                    )}
+                                </div>
+
+                                <Link
+                                    to={`/predictions/new?live_id=${liveId}`}
+                                    className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white font-bold px-4 py-2.5 rounded-xl shadow-lg shadow-blue-900/20 flex items-center justify-center gap-2 transition-all"
+                                >
+                                    <Plus size={18} />
+                                    予想を投稿する
+                                </Link>
                             </div>
 
                             <Link
-                                to={`/predictions/new?live_id=${liveId}`}
-                                className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white font-bold px-6 py-3 rounded-xl shadow-lg shadow-blue-900/20 flex items-center justify-center gap-2 transition-all hover:-translate-y-0.5 active:translate-y-0"
+                                to="/predictions"
+                                className="text-xs text-slate-400 hover:text-blue-400 flex items-center gap-1.5 transition-colors bg-slate-800/40 hover:bg-slate-800/70 border border-slate-700/50 hover:border-blue-500/30 px-3 py-2 rounded-lg w-fit"
                             >
-                                <Plus size={20} />
-                                予想を投稿する
+                                <Calendar size={12} />
+                                他のライブを見る
                             </Link>
                         </div>
 

--- a/src/pages/PredictionRanking.tsx
+++ b/src/pages/PredictionRanking.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate, useLocation, useSearchParams } from 'react-router-dom';
-import { Heart, Plus, Calendar, User, Sparkles, Eye, PenTool, MapPin } from 'lucide-react';
+import { Heart, Plus, Calendar, User, Sparkles, Eye, PenTool, MapPin, Trophy } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import PageHeader from '../components/Layout/PageHeader';
 import SEO from '../components/SEO';
@@ -64,6 +64,9 @@ const PredictionRanking = () => {
 
         likeMutation.mutate(id);
     };
+
+    // スコアが算出済みかどうか（1件でも total_score があれば true）
+    const hasScores = predictions.some(p => p.total_score != null);
 
     // 自分の投稿をトップに持ってくるためのソート済み配列
     const sortedPredictions = [...predictions].sort((a, b) => {
@@ -323,6 +326,15 @@ const PredictionRanking = () => {
                                 >
                                     新着順
                                 </button>
+                                {hasScores && (
+                                    <button
+                                        onClick={() => setSortBy('score')}
+                                        className={`px-6 py-2 rounded-lg text-sm font-bold transition-all flex items-center gap-1.5 ${sortBy === 'score' ? 'bg-yellow-500 text-black shadow-lg' : 'text-slate-400 hover:text-slate-200'}`}
+                                    >
+                                        <Trophy size={14} />
+                                        スコア順
+                                    </button>
+                                )}
                             </div>
 
                             <Link
@@ -357,8 +369,8 @@ const PredictionRanking = () => {
                                         
                                         <div className={`bg-slate-800/50 hover:bg-slate-800 border border-slate-700 group-hover:border-blue-500/50 rounded-2xl p-5 transition-all duration-300 hover:transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-blue-900/20 flex items-center`}>
                                             <div className="w-10 text-center mr-4">
-                                                {sortBy === 'popular' ? (
-                                                    <span className={`text-2xl font-black ${index === 0 && !prediction.is_mine ? 'text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.4)]' : index === 1 ? 'text-slate-300' : index === 2 ? 'text-amber-600' : 'text-slate-600'}`}>
+                                                {sortBy === 'popular' || sortBy === 'score' ? (
+                                                    <span className={`text-2xl font-black ${index === 0 ? 'text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.4)]' : index === 1 ? 'text-slate-300' : index === 2 ? 'text-amber-600' : 'text-slate-600'}`}>
                                                         {index + 1}
                                                     </span>
                                                 ) : (
@@ -402,20 +414,45 @@ const PredictionRanking = () => {
                                             </div>
 
                                             <div className="flex flex-col items-center gap-2 border-l border-slate-700/50 pl-6">
-                                                {!prediction.is_mine && (
-                                                    <FollowButton targetUserId={prediction.user_id} size="sm" />
+                                                {prediction.total_score != null ? (
+                                                    <div className="flex flex-col items-center gap-0.5">
+                                                        <div className="flex items-center gap-1 text-yellow-400">
+                                                            <Trophy size={14} />
+                                                            <span className="text-xl font-black tabular-nums">
+                                                                {Number(prediction.total_score).toFixed(1)}
+                                                            </span>
+                                                        </div>
+                                                        <span className="text-[10px] text-slate-500 font-bold">/ 100pt</span>
+                                                        <div className="flex gap-1 mt-1">
+                                                            <span className="text-[9px] bg-blue-900/50 text-blue-300 px-1.5 py-0.5 rounded font-bold" title="一致スコア">
+                                                                M {Number(prediction.match_score ?? 0).toFixed(0)}
+                                                            </span>
+                                                            <span className="text-[9px] bg-purple-900/50 text-purple-300 px-1.5 py-0.5 rounded font-bold" title="順番スコア">
+                                                                P {Number(prediction.position_score ?? 0).toFixed(0)}
+                                                            </span>
+                                                            <span className="text-[9px] bg-green-900/50 text-green-300 px-1.5 py-0.5 rounded font-bold" title="連続ボーナス">
+                                                                S {Number(prediction.streak_bonus ?? 0).toFixed(0)}
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                ) : (
+                                                    <>
+                                                        {!prediction.is_mine && (
+                                                            <FollowButton targetUserId={prediction.user_id} size="sm" />
+                                                        )}
+                                                        <button
+                                                            onClick={(e) => handleLike(e, prediction.id)}
+                                                            className={`group/like flex flex-col items-center gap-1 p-2 rounded-xl transition-all ${prediction.is_liked ? 'text-pink-500' : 'text-slate-500 hover:bg-pink-500/10 hover:text-pink-400'}`}
+                                                        >
+                                                            <Heart
+                                                                size={24}
+                                                                fill={prediction.is_liked ? "currentColor" : "none"}
+                                                                className={`transition-transform duration-300 ${prediction.is_liked ? 'scale-110' : 'group-hover/like:scale-110'}`}
+                                                            />
+                                                            <span className="text-xs font-black tracking-tighter">{prediction.like_count}</span>
+                                                        </button>
+                                                    </>
                                                 )}
-                                                <button
-                                                    onClick={(e) => handleLike(e, prediction.id)}
-                                                    className={`group/like flex flex-col items-center gap-1 p-2 rounded-xl transition-all ${prediction.is_liked ? 'text-pink-500' : 'text-slate-500 hover:bg-pink-500/10 hover:text-pink-400'}`}
-                                                >
-                                                    <Heart
-                                                        size={24}
-                                                        fill={prediction.is_liked ? "currentColor" : "none"}
-                                                        className={`transition-transform duration-300 ${prediction.is_liked ? 'scale-110' : 'group-hover/like:scale-110'}`}
-                                                    />
-                                                    <span className="text-xs font-black tracking-tighter">{prediction.like_count}</span>
-                                                </button>
                                             </div>
                                         </div>
                                     </Link>

--- a/src/pages/SetlistPredictionDetail.tsx
+++ b/src/pages/SetlistPredictionDetail.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { Heart, User, Calendar, MapPin, Music, ArrowLeft, Share2, Sparkles, ChevronRight, Copy } from 'lucide-react';
+import { Heart, Calendar, MapPin, Music, ArrowLeft, Share2, Sparkles, ChevronRight, Copy, Trophy } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { usePredictionDetail, useLikePrediction } from '../hooks/queries/usePredictions';
 import PageHeader from '../components/Layout/PageHeader';
@@ -28,6 +28,14 @@ const SetlistPredictionDetail = () => {
         } catch (error) {
             console.error('Error toggling like:', error);
         }
+    };
+
+    const getScoreLabel = (score: number) => {
+        if (score >= 90) return { label: '神予想', color: 'text-yellow-400' };
+        if (score >= 75) return { label: '優秀', color: 'text-blue-400' };
+        if (score >= 50) return { label: '合格', color: 'text-green-400' };
+        if (score >= 25) return { label: '惜しい', color: 'text-orange-400' };
+        return { label: '次回に期待', color: 'text-slate-400' };
     };
 
     const handleShare = () => {
@@ -146,6 +154,55 @@ const SetlistPredictionDetail = () => {
                             </div>
                         )}
 
+                        {/* スコア結果パネル */}
+                        {prediction.total_score != null && (() => {
+                            const score = Number(prediction.total_score);
+                            const { label, color } = getScoreLabel(score);
+                            return (
+                                <div className="bg-gradient-to-br from-yellow-500/10 to-amber-600/5 border border-yellow-500/30 rounded-2xl p-6 mb-10">
+                                    <div className="flex items-center gap-2 text-yellow-400 mb-4">
+                                        <Trophy size={18} />
+                                        <span className="text-xs font-black tracking-widest uppercase">スコア結果</span>
+                                    </div>
+                                    <div className="flex flex-col md:flex-row md:items-center gap-6">
+                                        <div className="flex flex-col items-center md:items-start">
+                                            <div className={`text-6xl font-black tabular-nums ${color}`}>
+                                                {score.toFixed(1)}
+                                            </div>
+                                            <div className="text-slate-500 text-sm font-bold">/ 100pt</div>
+                                            <div className={`mt-1 text-sm font-black ${color}`}>{label}</div>
+                                        </div>
+                                        <div className="flex-1 space-y-3">
+                                            <div className="flex items-center gap-3">
+                                                <span className="text-xs font-bold text-slate-500 w-20">一致スコア</span>
+                                                <div className="flex-1 bg-slate-800 rounded-full h-2 overflow-hidden">
+                                                    <div className="h-full bg-blue-500 rounded-full transition-all" style={{ width: `${Math.min((Number(prediction.match_score ?? 0) / 70) * 100, 100)}%` }} />
+                                                </div>
+                                                <span className="text-sm font-black text-blue-400 tabular-nums w-12 text-right">{Number(prediction.match_score ?? 0).toFixed(1)}</span>
+                                            </div>
+                                            <div className="flex items-center gap-3">
+                                                <span className="text-xs font-bold text-slate-500 w-20">順番スコア</span>
+                                                <div className="flex-1 bg-slate-800 rounded-full h-2 overflow-hidden">
+                                                    <div className="h-full bg-purple-500 rounded-full transition-all" style={{ width: `${Math.min((Number(prediction.position_score ?? 0) / 20) * 100, 100)}%` }} />
+                                                </div>
+                                                <span className="text-sm font-black text-purple-400 tabular-nums w-12 text-right">{Number(prediction.position_score ?? 0).toFixed(1)}</span>
+                                            </div>
+                                            <div className="flex items-center gap-3">
+                                                <span className="text-xs font-bold text-slate-500 w-20">連続ボーナス</span>
+                                                <div className="flex-1 bg-slate-800 rounded-full h-2 overflow-hidden">
+                                                    <div className="h-full bg-green-500 rounded-full transition-all" style={{ width: `${Math.min((Number(prediction.streak_bonus ?? 0) / 10) * 100, 100)}%` }} />
+                                                </div>
+                                                <span className="text-sm font-black text-green-400 tabular-nums w-12 text-right">{Number(prediction.streak_bonus ?? 0).toFixed(1)}</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div className="mt-4 pt-4 border-t border-yellow-500/20 text-xs text-slate-500 font-medium">
+                                        予想 {prediction.predicted_count}曲 → 一致 <span className="text-white font-bold">{prediction.matched_count}曲</span> / 実際 {prediction.actual_count}曲
+                                    </div>
+                                </div>
+                            );
+                        })()}
+
                         <div className="space-y-3">
                             <h2 className="text-xs font-black tracking-[0.3em] text-slate-500 uppercase mb-4 pl-1">予想セットリスト</h2>
                             {prediction.songs?.map((song, index) => (
@@ -174,10 +231,12 @@ const SetlistPredictionDetail = () => {
                 </div>
 
                 <div className="mt-12 space-y-6">
-                    {/* Share Section - Only show for owner */}
-                    {prediction.is_mine && (
+                    {/* Share Section - スコアあり時は全員、なしはオーナーのみ */}
+                    {(prediction.is_mine || prediction.total_score != null) && (
                         <div className="bg-slate-800/30 rounded-3xl p-8 border border-slate-700/50 text-center">
-                            <p className="text-slate-400 text-sm mb-6 font-medium">この予想をあなたのSNSでシェアしませんか？</p>
+                            <p className="text-slate-400 text-sm mb-6 font-medium">
+                                {prediction.total_score != null ? 'スコア結果をXでシェアしよう！' : 'この予想をあなたのSNSでシェアしませんか？'}
+                            </p>
                             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
                                 <button 
                                     onClick={() => {
@@ -191,10 +250,13 @@ const SetlistPredictionDetail = () => {
                                         const url = window.location.href;
                                         const tourTag = prediction.tour_name ? prediction.tour_name.replace(/\s+/g, '') : '';
                                         
-                                        const headerText = `セットリストを予想しました！`;
-                                        
-                                        // 本文にURLとハッシュタグを詰め込んで改行を制御
-                                        const text = `${headerText}\n${prediction.tour_name}\n${dateStr} @ ${prediction.venue}\n\n${songsText}\n\nセトリ予想はこちらから👇\n${url}\n\n#UVERworld #セトリ予想 ${tourTag ? '#' + tourTag : ''}`;
+                                        const hasScore = prediction.total_score != null;
+                                        const scoreText = hasScore
+                                            ? `\nスコア: ${Number(prediction.total_score).toFixed(1)}pt (${getScoreLabel(Number(prediction.total_score)).label}) | 一致: ${prediction.matched_count}/${prediction.actual_count}曲\n`
+                                            : '';
+                                        const headerText = hasScore ? `セトリ予想の結果が出ました！` : `セットリストを予想しました！`;
+
+                                        const text = `${headerText}\n${prediction.tour_name}\n${dateStr} @ ${prediction.venue}${scoreText}\n${songsText}\n\nセトリ予想はこちらから👇\n${url}\n\n#UVERworld #セトリ予想 ${tourTag ? '#' + tourTag : ''}`;
                                         
                                         const xUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
                                         window.open(xUrl, '_blank');

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -97,6 +97,15 @@ export interface Prediction {
   live_date?: string
   venue?: string
   songs?: Array<{ id: number; title: string }>
+  // スコアフィールド（ライブ終了後に算出）
+  total_score?: number | null
+  match_score?: number | null
+  position_score?: number | null
+  streak_bonus?: number | null
+  matched_count?: number | null
+  predicted_count?: number | null
+  actual_count?: number | null
+  rank?: number | null
 }
 
 // セトリ予想作成リクエスト


### PR DESCRIPTION
## 変更内容

### LatestLiveCard
- 見出し: ont-size: clamp(1.3rem, 4vw, 1.8rem) で画面幅に応じて自動縮小
- ボタン: 480px以下で縦並び（lex-direction: column）＋全幅（width: 100%）

### UpcomingLives
- グリッド: minmax(300px, 1fr) → minmax(min(300px, 100%), 1fr) に変更
- 極小画面（300px未満）でも横スクロールが発生しなくなる

### PredictionRanking
- ソートタブをモバイルで全幅表示に改善
- ボタンのレスポンシブ配置を最適化
- 「他のライブを見る」リンクの追加

## 確認済み
- 320px / 375px / 380px / 480px / デスクトップ幅で表示確認済み
- 横スクロール発生なし