### PR TITLE
fix: prediction_songs の order_index を正しい position カラム名に修正

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 
 const app = express();
+app.set('trust proxy', 1);
 const PORT = process.env.PORT || 8000;
 
 // Security Check: Ensure JWT_SECRET is configured

--- a/server/routes/predictions.js
+++ b/server/routes/predictions.js
@@ -133,11 +133,11 @@ router.get('/:id', async (req, res) => {
 
         // Get songs
         const songsResult = await db.query(`
-            SELECT ps.order_index as position, s.id, s.title
+            SELECT ps.position, s.id, s.title
             FROM prediction_songs ps
             JOIN songs s ON ps.song_id = s.id
             WHERE ps.prediction_id = $1
-            ORDER BY ps.order_index ASC
+            ORDER BY ps.position ASC
         `, [id]);
 
         res.json({
@@ -175,7 +175,7 @@ router.post('/', authorize, async (req, res) => {
         // Insert songs
         for (let i = 0; i < songs.length; i++) {
             await client.query(`
-                INSERT INTO prediction_songs (prediction_id, song_id, order_index)
+                INSERT INTO prediction_songs (prediction_id, song_id, position)
                 VALUES ($1, $2, $3)
             `, [predictionId, songs[i], i + 1]);
         }


### PR DESCRIPTION
本番DBで CREATE prediction error が発生していた原因。
migration 008 で position として作成されたカラムを
コードが誤って order_index と参照していた。
また express trust proxy を設定して rate-limit の警告を解消。