### PR TITLE
fix: セトリ予想およびダッシュボードの日付表示バグの修正

### DIFF
--- a/server/routes/lives.js
+++ b/server/routes/lives.js
@@ -88,7 +88,7 @@ router.get('/', async (req, res) => {
                 GROUP BY l.id
                 ${havingClause}
             )
-            SELECT l.*
+            SELECT l.id, l.tour_name, l.title, l.date::text as date, l.venue, l.type, l.prefecture, l.special_note, l.setlistfm_id, l.setlist_status
         `;
 
         if (include_setlists === 'true') {
@@ -141,7 +141,7 @@ router.get('/:id', async (req, res) => {
 
         // 1. Get Live Details with prediction count
         const liveRes = await db.query(
-            `SELECT l.*, 
+            `SELECT id, tour_name, title, date::text as date, venue, type, prefecture, special_note, setlistfm_id, setlist_status, 
                     (SELECT COUNT(*) FROM predictions p WHERE p.live_id = l.id) as prediction_count
              FROM lives l WHERE id = $1`, 
             [id]

--- a/server/routes/predictions.js
+++ b/server/routes/predictions.js
@@ -7,7 +7,7 @@ router.get('/lives', async (req, res) => {
     try {
         const result = await db.query(`
             SELECT 
-                l.id, l.tour_name, l.title, l.date, l.venue, l.type,
+                l.id, l.tour_name, l.title, l.date::text as date, l.venue, l.type,
                 COUNT(p.id) as prediction_count
             FROM lives l
             LEFT JOIN predictions p ON l.id = p.live_id
@@ -56,7 +56,7 @@ router.get('/', async (req, res) => {
             SELECT 
                 p.*, 
                 u.username,
-                li.tour_name, li.venue, li.date as live_date,
+                li.tour_name, li.venue, li.date::text as live_date,
                 COUNT(DISTINCT pl.user_id) as like_count,
                 EXISTS(SELECT 1 FROM prediction_likes WHERE prediction_id = p.id AND user_id = $1) as is_liked,
                 (p.user_id = $1) as is_mine
@@ -118,7 +118,7 @@ router.get('/:id', async (req, res) => {
                 COUNT(DISTINCT l.user_id) as like_count,
                 EXISTS(SELECT 1 FROM prediction_likes WHERE prediction_id = p.id AND user_id = $1) as is_liked,
                 (p.user_id = $1) as is_mine,
-                li.tour_name, li.venue, li.date as live_date
+                li.tour_name, li.venue, li.date::text as live_date
             FROM predictions p
             JOIN users u ON p.user_id = u.id
             LEFT JOIN prediction_likes l ON p.id = l.prediction_id

--- a/src/components/Dashboard/UpcomingLives.jsx
+++ b/src/components/Dashboard/UpcomingLives.jsx
@@ -64,7 +64,7 @@ export const UpcomingLives = ({ lives }) => {
                                     <Calendar size={16} color="var(--primary-color)" />
                                     <span style={{ fontWeight: 'bold', color: '#fff' }}>
                                         {(() => {
-                                            const d = new Date(live.date);
+                                            const d = new Date(live.date.split('T')[0].replace(/-/g, '/'));
                                             return isNaN(d.getTime()) ? live.date : d.toLocaleDateString('ja-JP', {
                                                 year: 'numeric',
                                                 month: '2-digit',

--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -49,7 +49,7 @@ export const useGlobalStats = () => {
 
         const formatDate = (dateStr: string | null | undefined): string => {
             if (!dateStr) return '';
-            const d = new Date(dateStr);
+            const d = new Date(dateStr.split('T')[0].replace(/-/g, '/'));
             return d.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\//g, '.');
         };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -38,7 +38,7 @@ function Dashboard() {
 
     const formatDate = (dateStr: string | null | undefined) => {
         if (!dateStr) return '';
-        const d = new Date(dateStr);
+        const d = new Date(dateStr.split('T')[0].replace(/-/g, '/'));
         return d.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\//g, '.');
     };
 

--- a/src/pages/LiveDetail.tsx
+++ b/src/pages/LiveDetail.tsx
@@ -121,7 +121,7 @@ function LiveDetail() {
                         </span>
                         <div className="h-px flex-1 bg-slate-800"></div>
                         <span className="text-base font-bold font-mono text-slate-400">
-                            {new Date(live.date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replaceAll('/', '.')}
+                            {new Date(live.date.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replaceAll('/', '.')}
                         </span>
                     </div>
 
@@ -263,8 +263,8 @@ function LiveDetail() {
                 {/* セトリ予想セクション */}
                 <div className="mt-12">
                     {(() => {
-                        const PREDICTION_START_DATE = new Date('2026-05-01');
-                        const liveDate = new Date(live.date);
+                        const PREDICTION_START_DATE = new Date('2026/05/01');
+                        const liveDate = new Date(live.date.split('T')[0].replace(/-/g, '/'));
                         const today = new Date();
                         today.setHours(0, 0, 0, 0);
 

--- a/src/pages/PredictionRanking.tsx
+++ b/src/pages/PredictionRanking.tsx
@@ -146,7 +146,7 @@ const PredictionRanking = () => {
                                                         開催予定
                                                     </span>
                                                     <span className="text-slate-500 text-xs font-bold">
-                                                        {new Date(live.date).toLocaleDateString('ja-JP', { month: '2-digit', day: '2-digit', weekday: 'short' }).replace(/\//g, '.')}
+                                                        {new Date(live.date.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP', { month: '2-digit', day: '2-digit', weekday: 'short' }).replace(/\//g, '.')}
                                                     </span>
                                                 </div>
                                                 <h3 className="text-xl font-bold text-white group-hover:text-blue-400 transition-colors">
@@ -225,7 +225,7 @@ const PredictionRanking = () => {
                                                     <div className="flex flex-wrap items-center gap-y-1 gap-x-4 text-xs text-slate-500 font-medium">
                                                         <div className="flex items-center gap-1.5">
                                                             <Calendar size={12} />
-                                                            {prediction.live_date ? new Date(prediction.live_date).toLocaleDateString('ja-JP') : ''}
+                                                            {prediction.live_date ? new Date(prediction.live_date.replace(/-/g, '/')).toLocaleDateString('ja-JP') : ''}
                                                         </div>
                                                         <div className="flex items-center gap-1.5">
                                                             <MapPin size={12} />
@@ -264,7 +264,7 @@ const PredictionRanking = () => {
                                                         {liveInfo.tour_name || 'Special Live'}
                                                     </h3>
                                                     <p className="text-slate-400 text-sm mt-1">
-                                                        {liveInfo.date ? new Date(liveInfo.live_date || liveInfo.date).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'short' }) : ''}
+                                                        {liveInfo.date ? new Date((liveInfo.live_date || liveInfo.date).split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'short' }) : ''}
                                                         <span className="mx-2">/</span>
                                                         {liveInfo.venue}
                                                     </p>
@@ -296,7 +296,7 @@ const PredictionRanking = () => {
                                                 >
                                                     {tourLives.map(l => (
                                                         <option key={l.id} value={l.id}>
-                                                            {new Date(l.date).toLocaleDateString('ja-JP')} @ {l.venue}
+                                                            {new Date(l.date.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP')} @ {l.venue}
                                                         </option>
                                                     ))}
                                                 </select>
@@ -412,7 +412,7 @@ const PredictionRanking = () => {
                                                     </div>
                                                     <div className="flex items-center gap-1.5">
                                                         <Calendar size={12} />
-                                                        {new Date(prediction.created_at).toLocaleDateString('ja-JP')}
+                                                        {new Date(prediction.created_at.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP')}
                                                     </div>
                                                 </div>
                                             </div>

--- a/src/pages/SetlistPredictionCreate.tsx
+++ b/src/pages/SetlistPredictionCreate.tsx
@@ -74,8 +74,8 @@ const SetlistPredictionCreate = () => {
     // 過去のライブや、予想開始日以前のライブへの投稿を制限
     useEffect(() => {
         if (liveInfo) {
-            const liveDate = new Date(liveInfo.date);
-            const PREDICTION_START_DATE = new Date('2026-05-01');
+            const liveDate = new Date(liveInfo.date.split('T')[0].replace(/-/g, '/'));
+            const PREDICTION_START_DATE = new Date('2026/05/01');
             const today = new Date();
             today.setHours(0, 0, 0, 0);
             const isPastLive = liveDate < today;
@@ -167,7 +167,7 @@ const SetlistPredictionCreate = () => {
                             <div>
                                 <div className="text-white font-bold leading-tight mb-1">{liveInfo.tour_name || 'スペシャルライブ'}</div>
                                 <div className="text-sm text-slate-400">
-                                    {liveInfo.date ? new Date(liveInfo.date).toISOString().split('T')[0] : ''} @ {liveInfo.venue}
+                                    {liveInfo.date ? liveInfo.date.split('T')[0] : ''} @ {liveInfo.venue}
                                 </div>
                             </div>
                         </div>
@@ -185,7 +185,7 @@ const SetlistPredictionCreate = () => {
                                 >
                                     {tourLives.map(l => (
                                         <option key={l.id} value={l.id}>
-                                            {l.date ? new Date(l.date).toISOString().split('T')[0] : ''} @ {l.venue}
+                                            {l.date ? l.date.split('T')[0] : ''} @ {l.venue}
                                         </option>
                                     ))}
                                 </select>

--- a/src/pages/SetlistPredictionDetail.tsx
+++ b/src/pages/SetlistPredictionDetail.tsx
@@ -106,7 +106,7 @@ const SetlistPredictionDetail = () => {
                                 <div className="flex flex-wrap items-center gap-4 text-slate-400 text-sm">
                                     <div className="flex items-center gap-1.5">
                                         <Calendar size={14} />
-                                        {new Date(prediction.created_at).toLocaleDateString('ja-JP')}
+                                        {new Date(prediction.created_at.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP')}
                                     </div>
                                     <div className="w-1 h-1 bg-slate-700 rounded-full"></div>
                                     <div className="flex items-center gap-1.5">
@@ -140,7 +140,7 @@ const SetlistPredictionDetail = () => {
                                     <div className="text-lg font-bold text-white mb-1">{prediction.tour_name}</div>
                                     <div className="flex items-center gap-3 text-sm text-slate-400">
                                         <span className="flex items-center gap-1"><MapPin size={14} /> {prediction.venue}</span>
-                                        <span className="flex items-center gap-1"><Calendar size={14} /> {prediction.live_date ? new Date(prediction.live_date).toLocaleDateString('ja-JP') : ''}</span>
+                                        <span className="flex items-center gap-1"><Calendar size={14} /> {prediction.live_date ? new Date(prediction.live_date.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP') : ''}</span>
                                     </div>
                                 </div>
                             </div>
@@ -181,7 +181,7 @@ const SetlistPredictionDetail = () => {
                             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
                                 <button 
                                     onClick={() => {
-                                        const dateStr = prediction.live_date ? new Date(prediction.live_date).toLocaleDateString('ja-JP', {
+                                        const dateStr = prediction.live_date ? new Date(prediction.live_date.split('T')[0].replace(/-/g, '/')).toLocaleDateString('ja-JP', {
                                             year: 'numeric',
                                             month: '2-digit',
                                             day: '2-digit'


### PR DESCRIPTION
セトリ予想ページとダッシュボードで日付が1日ずれて表示される問題を修正しました。JSのタイムゾーン解釈の差異を吸収するため、日付部分のみをスラッシュ形式でパースするように統一しています。