### PR TITLE
fix: フロントエンドの npm install に --legacy-peer-deps を復元

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,7 +30,7 @@ jobs:
 
           # 6. フロントエンドビルド
           cd ~/apps/uver-setlist-app
-          npm install
+          npm install --legacy-peer-deps
           npm run build
 
           # 7. サービス再起動


### PR DESCRIPTION
react-helmet-async@2.0.5 が React 19 の peer deps に非対応のため必要。 バックエンド側は不要なので除外したまま。