### PR TITLE
feat: ダッシュボードとマイページに防御的レンダリングを導入

### DIFF
--- a/docs/defensive_rendering_guide.md
+++ b/docs/defensive_rendering_guide.md
@@ -1,0 +1,53 @@
+# マイページ・ダッシュボードの防御的レンダリングの実装
+
+本ドキュメントでは、ダッシュボードおよびマイページにおいて発生していた「白画面クラッシュ」を防ぐために導入された、防御的レンダリングとデータ正規化の仕組みについて解説します。
+
+## 1. コア・コンセプト
+
+「壊れたデータが来ても、UIを落とさない」という方針に基づき、以下の3層の防御を実装しています。
+
+1.  **データ正規化レイヤー (Data Normalization)**: APIからのRawデータを、UIが期待する型に変換し、欠損値にはデフォルト値を補完します。
+2.  **コンポーネント・ガード (Defensive Rendering)**: 各コンポーネント内でデータの存在・型・妥当性をチェックし、不正なデータは描画から除外、または安全なフォールバックを表示します。
+3.  **エラー境界 (Error Boundary)**: 万が一レンダリング中にエラーが発生しても、そのコンポーネントのみを停止し、ページ全体のクラッシュを防ぎます。
+
+## 2. データ正規化レイヤー
+
+`src/lib/normalizers/dataNormalizer.ts` に共通の正規化ロジックを配置しています。
+
+-   `normalizeLive(raw)`: ライブデータの補完（ID、タイトル、日付、会場名など）。
+-   `normalizeSong(raw)`: 楽曲データの補完。
+-   `safeDate(dateStr)`: 無効な日付（Invalid Date）を避け、安全なDateオブジェクトまたはデフォルト値を返します。
+
+### Hookでの利用例 (`useLiveStats.ts`)
+```typescript
+const { data: attendedLives = [], refetch } = useAttendedLives();
+const normalizedLives = useMemo(() => attendedLives.map(normalizeLive), [attendedLives]);
+```
+
+## 3. コンポーネント・レベルの防御
+
+可視化コンポーネント（特にRechartsを使用するもの）では、以下のガードを徹底しています。
+
+-   **数値バリデーション**: `NaN` や `undefined` がグラフに渡らないよう、描画前にフィルタリングします。
+-   **空状態のハンドリング**: データが空の場合に「No Data」ではなく、一貫したデザインの「データがありません」メッセージを表示します。
+
+### 実装例 (`LiveGraph.jsx`)
+```javascript
+const safeData = React.useMemo(() => {
+    if (!data || !Array.isArray(data)) return [];
+    return data.filter(d => d && typeof d[dataKey] === 'number' && !isNaN(d[dataKey]));
+}, [data, dataKey]);
+```
+
+## 4. ErrorBoundary とリカバリ
+
+各ウィジェットは個別の `ErrorBoundary` で保護されています。
+
+-   **テレメトリ**: 発生したエラー、コンポーネントスタック、URLをコンソール（および将来的な監視サービス）に出力します。
+-   **再試行 (Retry)**: TanStack Queryの `refetch` をバインドしており、エラー発生時にユーザーが「再試行」ボタンを押すことで、データの再取得とコンポーネントの復旧が可能です。
+
+## 5. 開発者へのガイドライン
+
+-   新しい可視化コンポーネントを作成する際は、必ず `dataNormalizer.ts` の関数を介してデータを受け取るようにしてください。
+-   APIレスポンスの型が変わる場合は、まず正規化レイヤーを更新してください。
+-   コンポーネント内で `map` や `filter` を行う前に、必ず配列であることのチェックを入れてください。

--- a/src/components/Dashboard/AlbumDistribution.jsx
+++ b/src/components/Dashboard/AlbumDistribution.jsx
@@ -22,18 +22,38 @@ const CustomYAxisTick = ({ x, y, payload, fontSize }) => {
 };
 
 const AlbumDistribution = ({ data, onBarClick }) => {
-    if (!data || data.length === 0) return <div className="no-data">No Album Data</div>;
+    // データバリデーション: 数値かつ有効なデータのみを抽出
+    const safeData = React.useMemo(() => {
+        if (!data || !Array.isArray(data)) return [];
+        return data.filter(d => 
+            d && 
+            typeof d.value === 'number' && 
+            !isNaN(d.value)
+        );
+    }, [data]);
 
-    // Filter out "Unknown" if desired, or keep it.
-    // For now, let's keep it but maybe sort it last or color it differently.
+    if (safeData.length === 0) {
+        return (
+            <div style={{ 
+                height: 400, 
+                display: 'flex', 
+                alignItems: 'center', 
+                justifyContent: 'center',
+                color: '#64748b',
+                fontSize: '0.9rem',
+                border: '1px dashed rgba(255,255,255,0.1)',
+                borderRadius: '12px'
+            }}>
+                データがありません
+            </div>
+        );
+    }
 
     // Calculate height based on data length to ensure all bars are visible
-    // Allow approx 30-40px per bar + padding
-    const calculatedHeight = Math.max(400, data.length * 35 + 50);
+    const calculatedHeight = Math.max(400, safeData.length * 35 + 50);
 
     // Calculate dynamic ticks for XAxis (every 100 units)
-    // User request: Set max to at least 700, but allow growth (variable)
-    const maxValue = Math.max(...data.map(d => d.value), 0);
+    const maxValue = Math.max(...safeData.map(d => d.value), 0);
     const maxTick = Math.max(700, Math.ceil(maxValue / 100) * 100);
     const ticks = [];
     for (let i = 0; i <= maxTick; i += 100) {
@@ -60,7 +80,7 @@ const AlbumDistribution = ({ data, onBarClick }) => {
     return (
         <div style={{ width: '100%', height: calculatedHeight, minHeight: 0 }}>
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-                <BarChart data={data} layout="vertical" margin={{ top: 5, right: 30, left: 0, bottom: 5 }}>
+                <BarChart data={safeData} layout="vertical" margin={{ top: 5, right: 30, left: 0, bottom: 5 }}>
                     <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#444" />
                     <XAxis
                         type="number"
@@ -85,7 +105,7 @@ const AlbumDistribution = ({ data, onBarClick }) => {
                         cursor={{ fill: 'rgba(255,255,255,0.05)' }}
                     />
                     <Bar dataKey="value" radius={[0, 4, 4, 0]} onClick={onBarClick} style={{ cursor: 'pointer' }}>
-                        {data.map((entry, index) => (
+                        {safeData.map((entry, index) => (
                             <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} cursor="pointer" />
                         ))}
                         <LabelList dataKey="value" position="right" fill="#fbbf24" fontSize={12} />

--- a/src/components/Dashboard/LiveGraph.jsx
+++ b/src/components/Dashboard/LiveGraph.jsx
@@ -21,7 +21,32 @@ const CustomTooltip = ({ active, payload, label, dataKey, unitLabel }) => {
 };
 
 const LiveGraph = ({ data, onBarClick, dataKey = "count", label }) => {
-    if (!data || data.length === 0) return <div className="no-data">No Data</div>;
+    // データバリデーション: 数値かつ有効なデータのみを抽出
+    const safeData = React.useMemo(() => {
+        if (!data || !Array.isArray(data)) return [];
+        return data.filter(d => 
+            d && 
+            typeof d[dataKey] === 'number' && 
+            !isNaN(d[dataKey])
+        );
+    }, [data, dataKey]);
+
+    if (safeData.length === 0) {
+        return (
+            <div style={{ 
+                height: 300, 
+                display: 'flex', 
+                alignItems: 'center', 
+                justifyContent: 'center',
+                color: '#64748b',
+                fontSize: '0.9rem',
+                border: '1px dashed rgba(255,255,255,0.1)',
+                borderRadius: '12px'
+            }}>
+                データがありません
+            </div>
+        );
+    }
 
     const handleClick = (data) => {
         if (onBarClick && data && data.year) {
@@ -59,7 +84,7 @@ const LiveGraph = ({ data, onBarClick, dataKey = "count", label }) => {
     return (
         <div style={{ width: '100%', height: 300 }}>
             <ResponsiveContainer width="100%" height="100%" minWidth={0}>
-                <BarChart data={data} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
+                <BarChart data={safeData} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
                     <XAxis dataKey="year" stroke="#888" tick={{ fontSize: 11 }} />
                     <YAxis
                         stroke="#888"

--- a/src/components/Dashboard/TourTrends.jsx
+++ b/src/components/Dashboard/TourTrends.jsx
@@ -18,8 +18,18 @@ export const TourTrends = ({ tour }) => {
         }));
     };
 
-    // Pre-calculate rank to persist across sorts
-    const rankedData = tour.songRanking.map((s, i) => ({ ...s, rank: i + 1 }));
+    // Pre-calculate rank to persist across sorts with data validation
+    const rankedData = React.useMemo(() => {
+        if (!tour.songRanking || !Array.isArray(tour.songRanking)) return [];
+        return tour.songRanking
+            .filter(s => s && typeof s.count === 'number' && !isNaN(s.count))
+            .map((s, i) => ({ 
+                ...s, 
+                rank: i + 1,
+                title: s.title || 'Unknown Song',
+                percentage: s.percentage || '0.0'
+            }));
+    }, [tour.songRanking]);
 
     // Sort Data
     const sortedRanking = [...rankedData].sort((a, b) => {

--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null };
+    }
+
+    static getDerivedStateFromError(error) {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        // 詳細なエラーログ（将来的にSentry等へ送信することを想定）
+        const errorLog = {
+            message: error.message,
+            stack: error.stack,
+            componentStack: errorInfo.componentStack,
+            url: window.location.href,
+            pathname: window.location.pathname,
+            timestamp: new Date().toISOString(),
+            // ログインユーザー情報が必要な場合はここに追加
+        };
+
+        console.error("[ErrorBoundary] Caught an exception:", errorLog);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div style={{
+                    padding: '30px 20px',
+                    margin: '10px 0',
+                    background: 'rgba(30, 41, 59, 0.5)',
+                    border: '1px solid rgba(239, 68, 68, 0.2)',
+                    borderRadius: '16px',
+                    color: '#94a3b8',
+                    fontSize: '0.9rem',
+                    textAlign: 'center',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: '12px',
+                    backdropFilter: 'blur(8px)'
+                }}>
+                    <div style={{ fontSize: '2rem', marginBottom: '5px' }}>⚠️</div>
+                    <p style={{ fontWeight: 'bold', color: '#f87171', margin: 0 }}>
+                        表示中にエラーが発生したのだ...
+                    </p>
+                    <p style={{ fontSize: '0.8rem', opacity: 0.8, margin: 0 }}>
+                        データが正常に読み込めなかった可能性があるのだ。
+                    </p>
+                    <button 
+                        onClick={() => {
+                            if (this.props.onReset) this.props.onReset();
+                            this.setState({ hasError: false, error: null });
+                        }}
+                        style={{
+                            background: 'rgba(239, 68, 68, 0.2)',
+                            color: '#f87171',
+                            border: '1px solid rgba(239, 68, 68, 0.3)',
+                            padding: '6px 16px',
+                            borderRadius: '50px',
+                            fontSize: '0.85rem',
+                            fontWeight: 'bold',
+                            cursor: 'pointer',
+                            transition: 'all 0.2s'
+                        }}
+                        onMouseEnter={e => e.currentTarget.style.background = 'rgba(239, 68, 68, 0.3)'}
+                        onMouseLeave={e => e.currentTarget.style.background = 'rgba(239, 68, 68, 0.2)'}
+                    >
+                        再試行する
+                    </button>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;
+

--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -5,7 +5,8 @@ import { DISCOGRAPHY } from '../data/discography';
 import { useLives } from './queries/useLives';
 import { useSongs } from './queries/useSongs';
 import { STALE_TIMES } from '../lib/queryClient';
-import type { Song } from '../types/api';
+import type { Song, Live } from '../types/api';
+import { normalizeLive, normalizeSong } from '../lib/normalizers/dataNormalizer';
 
 const normalizeSongTitle = (title: string | null | undefined): string => {
     if (!title) return "";
@@ -38,7 +39,7 @@ interface StatsResponse {
 }
 
 export const useGlobalStats = () => {
-    const { data: statsData, isLoading: statsLoading, error: statsError } = useQuery<StatsResponse>({
+    const { data: rawStatsData, isLoading: statsLoading, error: statsError, refetch } = useQuery<StatsResponse>({
         queryKey: ['stats'],
         queryFn: async () => {
             const res = await axios.get('/api/stats');
@@ -47,16 +48,44 @@ export const useGlobalStats = () => {
         staleTime: STALE_TIMES.stats,
     });
 
-    // allLives はダッシュボードのモーダル（年別・アルバム別詳細）で使用
+    // データ正規化レイヤー
+    const statsData = useMemo(() => {
+        if (!rawStatsData) return null;
+        
+        return {
+            ...rawStatsData,
+            recentLives: (rawStatsData.recentLives || []).map(l => normalizeLive(l)),
+            upcomingLives: (rawStatsData.upcomingLives || []).map(l => normalizeLive(l)),
+            globalSongRanking: (rawStatsData.globalSongRanking || []).map(s => ({
+                ...s,
+                ...normalizeSong(s)
+            })),
+            tourRanking: (rawStatsData.tourRanking || []).map(t => ({
+                ...t,
+                songRanking: (t.songRanking || []).map((s: any) => ({
+                    ...s,
+                    lives: (s.lives || []).map((l: any) => normalizeLive(l))
+                }))
+            })),
+            currentTour: rawStatsData.currentTour ? {
+                ...rawStatsData.currentTour,
+                songRanking: (rawStatsData.currentTour.songRanking || []).map((s: any) => ({
+                    ...s,
+                    lives: (s.lives || []).map((l: any) => normalizeLive(l))
+                }))
+            } : null
+        };
+    }, [rawStatsData]);
+
     const { data: allLives = [] } = useLives({ include_setlists: true });
-    // songIdMap / songDataMap の完全なカバレッジのために全楽曲を取得
-    const { data: allSongs = [] } = useSongs();
+    const { data: rawAllSongs = [] } = useSongs();
+
+    const normalizedAllSongs = useMemo(() => (rawAllSongs as any[]).map(s => normalizeSong(s)), [rawAllSongs]);
 
     const loading = statsLoading;
     const error = statsError ? (statsError as Error).message : null;
 
     const derived = useMemo(() => {
-        // アルバム→楽曲マッピング（DISCOGRAPHY使用）
         const songAlbumMap = new Map<string, string>();
         DISCOGRAPHY.forEach((release: any) => {
             if (release.type === 'ALBUM') {
@@ -75,10 +104,9 @@ export const useGlobalStats = () => {
             }
         });
 
-        // 全楽曲の id / image_url マップ
         const songDataMap = new Map<string, { id: number; image_url: string | null }>();
         const songIdMap = new Map<string, number>();
-        (allSongs as Song[]).forEach(s => {
+        normalizedAllSongs.forEach(s => {
             songDataMap.set(s.title, { id: s.id, image_url: s.image_url });
             songIdMap.set(s.title, s.id);
         });
@@ -87,9 +115,8 @@ export const useGlobalStats = () => {
             return { songAlbumMap, songIdMap, songDataMap, albumStats: [] as Array<{ name: string; value: number }> };
         }
 
-        // アルバム別演奏数（サーバーの songFrequencyMap を使用）
         const albumMap = new Map<string, number>();
-        Object.entries(statsData.songFrequencyMap).forEach(([title, count]) => {
+        Object.entries(statsData.songFrequencyMap || {}).forEach(([title, count]) => {
             const norm = normalizeSongTitle(title);
             const album = songAlbumMap.get(norm);
             if (album) albumMap.set(album, (albumMap.get(album) || 0) + count);
@@ -104,12 +131,13 @@ export const useGlobalStats = () => {
         });
 
         return { albumStats, songAlbumMap, songIdMap, songDataMap };
-    }, [statsData, allSongs]);
+    }, [statsData, normalizedAllSongs]);
 
     return {
         loading,
         error,
-        allLives,
+        refetch,
+        allLives: (allLives as any[]).map(l => normalizeLive(l)),
         totalLives: statsData?.totalLives ?? 0,
         totalSongsPerformed: statsData?.totalSongsPerformed ?? 0,
         yearlyDetailedStats: statsData?.yearlyDetailedStats ?? [],
@@ -122,3 +150,4 @@ export const useGlobalStats = () => {
         ...derived,
     };
 };
+

--- a/src/hooks/useLiveStats.ts
+++ b/src/hooks/useLiveStats.ts
@@ -5,14 +5,15 @@ import { DISCOGRAPHY } from '../data/discography';
 import { useAttendedLives } from './queries/useUser';
 import { useSongs } from './queries/useSongs';
 import type { Live, Song } from '../types/api';
+import { normalizeLive, normalizeSong } from '../lib/normalizers/dataNormalizer';
 
 interface SongStat {
     count: number;
     lives: Live[];
 }
 
-export const useLiveStatsLogic = (myLives: Live[], allSongs: Song[] = []) => {
-    if (!myLives || myLives.length === 0) {
+export const useLiveStatsLogic = (myLives: any[], allSongs: any[] = []) => {
+    if (!myLives || !Array.isArray(myLives) || myLives.length === 0) {
         return {
             totalLives: 0,
             uniqueSongs: 0,
@@ -26,10 +27,18 @@ export const useLiveStatsLogic = (myLives: Live[], allSongs: Song[] = []) => {
         };
     }
 
-    const sortedLives = [...myLives].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    // 正規化レイヤーの適用
+    const normalizedLives = myLives.map(live => normalizeLive(live));
+    const normalizedSongs = allSongs.map(song => normalizeSong(song));
+
+    const sortedLives = [...normalizedLives].sort((a, b) => {
+        const timeA = new Date(a.date).getTime();
+        const timeB = new Date(b.date).getTime();
+        return (isNaN(timeA) ? 0 : timeA) - (isNaN(timeB) ? 0 : timeB);
+    });
 
     const songMetaMap = new Map<string, Song>();
-    allSongs.forEach(song => {
+    normalizedSongs.forEach(song => {
         if (song.title) songMetaMap.set(song.title, song);
     });
 
@@ -52,11 +61,13 @@ export const useLiveStatsLogic = (myLives: Live[], allSongs: Song[] = []) => {
 
         if (list.length === 0 && live.date) {
             const d = new Date(live.date);
-            const yyyy = d.getFullYear();
-            const mm = String(d.getMonth() + 1).padStart(2, '0');
-            const dd = String(d.getDate()).padStart(2, '0');
-            const key = `live_${yyyy}${mm}${dd}_01`;
-            list = (setlists as Record<string, Array<{ title: string }>>)[key] || [];
+            if (!isNaN(d.getTime())) {
+                const yyyy = d.getFullYear();
+                const mm = String(d.getMonth() + 1).padStart(2, '0');
+                const dd = String(d.getDate()).padStart(2, '0');
+                const key = `live_${yyyy}${mm}${dd}_01`;
+                list = (setlists as Record<string, Array<{ title: string }>>)[key] || [];
+            }
         }
 
         if (list.length === 0 && (setlists as Record<string | number, unknown>)[live.id]) {
@@ -64,6 +75,7 @@ export const useLiveStatsLogic = (myLives: Live[], allSongs: Song[] = []) => {
         }
 
         list.forEach(song => {
+            if (!song.title) return;
             if (!songStatsMap.has(song.title)) {
                 songStatsMap.set(song.title, { count: 0, lives: [] });
             }
@@ -99,10 +111,13 @@ export const useLiveStatsLogic = (myLives: Live[], allSongs: Song[] = []) => {
 
     const yearlyMap = new Map<string, number>();
     sortedLives.forEach(live => {
-        const dateStr = live.date || live.attended_at;
+        const dateStr = live.date;
         if (dateStr) {
-            const year = new Date(dateStr).getFullYear().toString();
-            yearlyMap.set(year, (yearlyMap.get(year) || 0) + 1);
+            const d = new Date(dateStr);
+            if (!isNaN(d.getTime())) {
+                const year = d.getFullYear().toString();
+                yearlyMap.set(year, (yearlyMap.get(year) || 0) + 1);
+            }
         }
     });
 
@@ -148,12 +163,18 @@ export const useLiveStatsLogic = (myLives: Live[], allSongs: Song[] = []) => {
 export const useLiveStats = () => {
     const { currentUser } = useAuth();
 
-    const { data: attendedLives = [], isLoading: livesLoading } = useAttendedLives(!!currentUser);
-    const { data: allSongs = [], isLoading: songsLoading } = useSongs();
+    const { data: attendedLives = [], isLoading: livesLoading, refetch: refetchLives } = useAttendedLives(!!currentUser);
+    const { data: allSongs = [], isLoading: songsLoading, refetch: refetchSongs } = useSongs();
 
     const loading = livesLoading || songsLoading;
 
-    const stats = useMemo(() => useLiveStatsLogic(attendedLives as Live[], allSongs as Song[]), [attendedLives, allSongs]);
+    const refetch = async () => {
+        await Promise.all([refetchLives(), refetchSongs()]);
+    };
 
-    return { ...stats, loading };
+    const stats = useMemo(() => useLiveStatsLogic(attendedLives as any[], allSongs as any[]), [attendedLives, allSongs]);
+
+    return { ...stats, loading, refetch };
 };
+
+

--- a/src/lib/normalizers/dataNormalizer.ts
+++ b/src/lib/normalizers/dataNormalizer.ts
@@ -1,0 +1,101 @@
+import { Live, Song, SetlistEntry } from '../../types/api';
+
+/**
+ * ライブデータの正規化を行う。
+ * APIからのレスポンスが不完全な場合でも、UIがクラッシュしないように安全なデフォルト値を保証する。
+ */
+export function normalizeLive(raw: any): Live {
+    if (!raw) {
+        console.warn('[Normalization] Received null/undefined live data');
+        return {
+            id: 0,
+            tour_name: 'Unknown Tour',
+            title: 'Unknown Live',
+            date: new Date().toISOString(),
+            venue: 'Unknown Venue',
+            type: 'HALL',
+            special_note: null,
+            setlist: []
+        };
+    }
+
+    // 必須フィールドの欠落チェックとログ
+    if (!raw.id || !raw.tour_name || !raw.date) {
+        console.warn('[Normalization] Potentially malformed live data detected:', raw);
+    }
+
+    return {
+        id: Number(raw.id) || 0,
+        tour_name: raw.tour_name || raw.title || 'Unknown Tour',
+        title: raw.title || null,
+        date: safeDate(raw.date || raw.attended_at || raw.live_date),
+        venue: raw.venue || 'Unknown Venue',
+        type: raw.type || 'HALL',
+        special_note: raw.special_note || null,
+        setlist: Array.isArray(raw.setlist) ? raw.setlist.map(normalizeSetlistEntry) : [],
+        attended_at: raw.attended_at ? safeDate(raw.attended_at) : undefined,
+        created_at: raw.created_at ? safeDate(raw.created_at) : undefined,
+        prediction_count: Number(raw.prediction_count) || 0,
+        setlist_status: raw.setlist_status || null,
+        is_closed: !!raw.is_closed,
+        has_predicted: !!raw.has_predicted,
+        my_prediction_id: raw.my_prediction_id || null
+    };
+}
+
+/**
+ * セットリストエントリーの正規化
+ */
+export function normalizeSetlistEntry(raw: any): SetlistEntry {
+    return {
+        id: Number(raw.id) || 0,
+        title: raw.title || 'Unknown Song',
+        order: Number(raw.order) || Number(raw.position) || 0,
+        is_encore: !!raw.is_encore,
+        album: raw.album || null,
+        note: raw.note || null,
+        position: Number(raw.position) || Number(raw.order) || 0
+    };
+}
+
+/**
+ * 楽曲データの正規化
+ */
+export function normalizeSong(raw: any): Song {
+    if (!raw) {
+        return {
+            id: 0,
+            title: 'Unknown Song',
+            album: null,
+            release_year: null,
+            mv_url: null,
+            author: null,
+            image_url: null
+        };
+    }
+
+    return {
+        id: Number(raw.id) || 0,
+        title: raw.title || 'Unknown Song',
+        album: raw.album || null,
+        release_year: Number(raw.release_year) || null,
+        mv_url: raw.mv_url || null,
+        author: raw.author || null,
+        image_url: raw.image_url || null,
+        spotify_track_id: raw.spotify_track_id || null,
+        yt_video_id: raw.yt_video_id || null
+    };
+}
+
+/**
+ * 日付の安全な変換
+ */
+export function safeDate(dateStr: any): string {
+    if (!dateStr) return new Date().toISOString();
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) {
+        console.warn(`[Normalization] Invalid date string: ${dateStr}`);
+        return new Date().toISOString();
+    }
+    return d.toISOString();
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import { TourTrends } from '../components/Dashboard/TourTrends';
 import { UpcomingLives } from '../components/Dashboard/UpcomingLives';
 
 import SEO from '../components/SEO';
+import ErrorBoundary from '../components/common/ErrorBoundary';
 
 type DashboardFilter = { type: string; value: any } | null
 type SongMapEntry = { title: string; id: any; count: number; lives: Array<{ id: any; date: string; venue: string; title?: string }> }
@@ -229,14 +230,18 @@ function Dashboard() {
 
                 {/* Latest Live Highlight with Trends */}
                 {stats.recentLives && stats.recentLives.length > 0 && (
-                    <LatestLiveCard
-                        live={stats.recentLives[0]}
-                    />
+                    <ErrorBoundary onReset={stats.refetch}>
+                        <LatestLiveCard
+                            live={stats.recentLives[0]}
+                        />
+                    </ErrorBoundary>
                 )}
 
                 {/* Upcoming Lives (Next Live) */}
                 {stats.upcomingLives && stats.upcomingLives.length > 0 && (
-                    <UpcomingLives lives={stats.upcomingLives} />
+                    <ErrorBoundary onReset={stats.refetch}>
+                        <UpcomingLives lives={stats.upcomingLives} />
+                    </ErrorBoundary>
                 )}
 
                 {/* Current Tour Trends (Compact) */}
@@ -247,9 +252,12 @@ function Dashboard() {
                             TOUR HIGHLIGHTS
                         </h2>
 
-                        <TourTrends tour={stats.currentTour} />
+                        <ErrorBoundary onReset={stats.refetch}>
+                            <TourTrends tour={stats.currentTour} />
+                        </ErrorBoundary>
                     </div>
                 )}
+
 
                 {/* Stats Cards */}
                 <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
@@ -328,12 +336,14 @@ function Dashboard() {
                                 Period: {yearRange[0]} - {yearRange[1]}
                             </div>
                         </div>
-                        <LiveGraph
-                            data={filteredGraphData}
-                            onBarClick={handleYearClick}
-                            dataKey={graphMetric}
-                            label="公演"
-                        />
+                        <ErrorBoundary onReset={stats.refetch}>
+                            <LiveGraph
+                                data={filteredGraphData}
+                                onBarClick={handleYearClick}
+                                dataKey={graphMetric}
+                                label="公演"
+                            />
+                        </ErrorBoundary>
                     </div>
                 </div>
 
@@ -477,56 +487,58 @@ function Dashboard() {
                             Songs by Album ({yearRange[0]} - {yearRange[1]})
                         </h3>
                         <div style={{ minHeight: '400px' }}>
-                            <AlbumDistribution data={(() => {
-                                if (!stats.allLives || !stats.songAlbumMap) return [];
+                        <ErrorBoundary onReset={stats.refetch}>
+                                <AlbumDistribution data={(() => {
+                                    if (!stats.allLives || !stats.songAlbumMap) return [];
 
-                                const targetLives = stats.allLives.filter(live => {
-                                    if (!live.date) return false;
-                                    const y = new Date(live.date).getFullYear();
-                                    return y >= yearRange[0] && y <= yearRange[1];
-                                });
+                                    const targetLives = stats.allLives.filter(live => {
+                                        if (!live.date) return false;
+                                        const y = new Date(live.date).getFullYear();
+                                        return y >= yearRange[0] && y <= yearRange[1];
+                                    });
 
-                                // Local normalization helper for consistency
-                                const normTitle = (t: string | null | undefined) => {
-                                    if (!t) return "";
-                                    if (t === "=") return "=";
-                                    return t.toLowerCase().replace(/[!'#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g, "").replace(/\s+/g, "");
-                                };
+                                    // Local normalization helper for consistency
+                                    const normTitle = (t: string | null | undefined) => {
+                                        if (!t) return "";
+                                        if (t === "=") return "=";
+                                        return t.toLowerCase().replace(/[!'#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g, "").replace(/\s+/g, "");
+                                    };
 
-                                const map = new Map();
-                                targetLives.forEach((live: any) => {
-                                    if (!live.setlist) return;
-                                    live.setlist.forEach((song: any) => {
-                                        if (!song || !song.title) return;
+                                    const map = new Map();
+                                    targetLives.forEach((live: any) => {
+                                        if (!live.setlist) return;
+                                        live.setlist.forEach((song: any) => {
+                                            if (!song || !song.title) return;
 
-                                        // Use Normalized Title to lookup in the map (which is also built with normalized keys now)
-                                        const nTitle = normTitle(song.title);
-                                        const album = stats.songAlbumMap?.get(nTitle);
+                                            // Use Normalized Title to lookup in the map (which is also built with normalized keys now)
+                                            const nTitle = normTitle(song.title);
+                                            const album = stats.songAlbumMap?.get(nTitle);
 
-                                        // Only count if mapped (Strict Album Only)
-                                        if (album) {
-                                            map.set(album, (map.get(album) || 0) + 1);
+                                            // Only count if mapped (Strict Album Only)
+                                            if (album) {
+                                                map.set(album, (map.get(album) || 0) + 1);
+                                            }
+                                        });
+                                    });
+
+                                    const result = [];
+
+                                    // Add "Singles" category FIRST
+                                    const singlesCount = map.get("Singles") || 0;
+                                    result.push({ name: "Singles", value: singlesCount });
+
+                                    // Add Albums in Chronological Order
+                                    DISCOGRAPHY.forEach(release => {
+                                        if (release.type === 'ALBUM') {
+                                            const count = map.get(release.title) || 0;
+                                            // Include all albums even if 0, for consistency with discography list
+                                            result.push({ name: release.title, value: count });
                                         }
                                     });
-                                });
 
-                                const result = [];
-
-                                // Add "Singles" category FIRST
-                                const singlesCount = map.get("Singles") || 0;
-                                result.push({ name: "Singles", value: singlesCount });
-
-                                // Add Albums in Chronological Order
-                                DISCOGRAPHY.forEach(release => {
-                                    if (release.type === 'ALBUM') {
-                                        const count = map.get(release.title) || 0;
-                                        // Include all albums even if 0, for consistency with discography list
-                                        result.push({ name: release.title, value: count });
-                                    }
-                                });
-
-                                return result;
-                            })()} onBarClick={handleAlbumClick} />
+                                    return result;
+                                })()} onBarClick={handleAlbumClick} />
+                            </ErrorBoundary>
                         </div>
                     </div>
                 </div>
@@ -589,7 +601,9 @@ function Dashboard() {
                         </div>
 
                         {selectedAnalysisTour ? (
-                            <TourTrends tour={selectedAnalysisTour} />
+                            <ErrorBoundary>
+                                <TourTrends tour={selectedAnalysisTour} />
+                            </ErrorBoundary>
                         ) : (
                             <div style={{ padding: '40px', textAlign: 'center', color: '#64748b' }}>
                                 Select a tour to view analysis

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -9,6 +9,7 @@ import SongRanking from '../components/Dashboard/SongRanking';
 import MyPageOnboarding from '../components/Dashboard/MyPageOnboarding';
 import { Music, Calendar, MapPin, Filter, Building2, User, Settings as SettingsIcon, ArrowRight, Users, Heart, Edit2, Plus, PenTool } from 'lucide-react';
 import SEO from '../components/SEO';
+import ErrorBoundary from '../components/common/ErrorBoundary';
 import { useAuth } from '../contexts/AuthContext';
 import { useMyFollowStats } from '../hooks/queries/useFollow';
 import { useFeed } from '../hooks/queries/useFeed';
@@ -262,7 +263,12 @@ function MyPage() {
                                 </div>
                                 <div style={{ marginTop: '15px' }}>
                                     <div style={{ fontSize: '0.9rem', color: '#94a3b8', marginBottom: '5px' }}>
-                                        {new Date(stats.firstLive.date).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'short' })}
+                                        {(() => {
+                                            const d = new Date(stats.firstLive.date);
+                                            return isNaN(d.getTime()) 
+                                                ? stats.firstLive.date 
+                                                : d.toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'short' });
+                                        })()}
                                     </div>
                                     <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'white', lineHeight: 1.3 }}>
                                         {stats.firstLive.tour_name}
@@ -272,6 +278,7 @@ function MyPage() {
                                         <span>{stats.firstLive.venue}</span>
                                     </div>
                                 </div>
+
                             </Link>
                         )}
                     </div>
@@ -299,21 +306,29 @@ function MyPage() {
                                 <option value="10" style={{ backgroundColor: '#1e293b', color: 'white' }}>直近10年</option>
                             </select>
                         </div>
-                        <LiveGraph data={filteredYearlyStats} onBarClick={handleYearClick} label="公演" />
+                        <ErrorBoundary onReset={stats.refetch}>
+                            <LiveGraph data={filteredYearlyStats} onBarClick={handleYearClick} label="公演" />
+                        </ErrorBoundary>
                     </div>
 
                     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '30px', marginBottom: '50px' }}>
                         <div className="dashboard-panel chart-panel">
                             <h3>参戦会場ランキング</h3>
+                        <ErrorBoundary onReset={stats.refetch}>
                             <VenueRanking venues={stats.venueRanking} onVenueClick={handleVenueClick} />
+                        </ErrorBoundary>
                         </div>
                         <div className="dashboard-panel chart-panel">
                             <h3>よく聴いた曲</h3>
+                        <ErrorBoundary onReset={stats.refetch}>
                             <SongRanking songs={stats.songRanking} />
+                        </ErrorBoundary>
                         </div>
                         <div className="dashboard-panel chart-panel" style={{ gridColumn: '1 / -1' }}>
                             <h3>アルバム別</h3>
+                        <ErrorBoundary onReset={stats.refetch}>
                             <AlbumDistribution data={stats.albumStats} onBarClick={handleAlbumClick} />
+                        </ErrorBoundary>
                         </div>
                         <div style={{ gridColumn: '1 / -1' }}>
                             <AttendedLiveList lives={stats.myLives} />


### PR DESCRIPTION
## 概要
本番環境で発生していたデータ不整合による白画面クラッシュを防ぐため、防御的レンダリングとデータ正規化レイヤーを導入しました。

## 変更内容
- **データ正規化レイヤーの導入**: APIからのRawデータを安全に処理する dataNormalizer を作成。
- **可視化コンポーネントの強化**: Recharts描画前の数値バリデーションを追加。
- **リカバリ機能付きErrorBoundary**: 各ウィジェットを個別に保護し、再試行（refetch）ボタンを実装。
- **技術ドキュメントの追加**: 今後の保守のためのガイドラインを docs/ に追加。

## 確認事項
- [x] dev ブランチで動作確認済み
- [x] 不正なデータ（nullやNaN）が含まれてもクラッシュしないことを確認