### PR TITLE
hotfix: 本番の Total Shows/Songs が 0 になる問題を修正

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -4,8 +4,10 @@ const { normalizeVenueName } = require('../utils/songTranslations');
 
 const formatDate = (dateStr) => {
     if (!dateStr) return '';
-    const d = new Date(dateStr.split('T')[0].replace(/-/g, '/'));
-    return d.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\//g, '.');
+    // node:20-slim は ICU データが限定的なため toLocaleDateString は使わない
+    const [year, month, day] = dateStr.split('T')[0].split(' ')[0].split('-');
+    if (!year || !month || !day) return dateStr;
+    return `${year}.${month}.${day}`;
 };
 
 router.get('/', async (req, res) => {
@@ -181,7 +183,8 @@ router.get('/', async (req, res) => {
             songFrequencyMap
         });
     } catch (err) {
-        console.error('Stats API error:', err);
+        console.error('[/api/stats] Error:', err.message);
+        console.error(err.stack);
         res.status(500).json({ message: 'Server Error', error: err.message });
     }
 });


### PR DESCRIPTION
## 問題

本番環境で「Total Shows: 0 / Total Songs: 0」が表示される。

## 原因

`server/routes/stats.js` の `formatDate` が `toLocaleDateString('ja-JP')` を使用しており、
本番サーバーの Node.js が `ja-JP` ロケールをサポートしていない場合にエラーが発生する。
`/api/stats` が 500 を返すと `useGlobalStats` の statsData が undefined になり、全カウントが 0 になる。

staging (node:20-slim) でも同じ問題が発生し、同じ修正で解消済み。

## 修正内容

`toLocaleDateString('ja-JP')` を `YYYY-MM-DD` 文字列の単純分割に置き換え。
ロケール非依存のため Node.js ICU 環境に左右されない。

## テスト

- staging でダッシュボードの表示を確認済み ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)