### PR TITLE
feat: LatestLive/NextLive の切り替え条件を改善

### DIFF
--- a/server/routes/lives.js
+++ b/server/routes/lives.js
@@ -254,6 +254,11 @@ router.put('/:id/setlist', authorize, adminCheck, async (req, res) => {
                     [id, songId, position]
                 );
             }
+            // 曲が1曲以上登録されたらNORMALに自動更新
+            await db.query(
+                "UPDATE lives SET setlist_status = 'NORMAL' WHERE id = $1",
+                [id]
+            );
         }
 
         await db.query("COMMIT");
@@ -300,6 +305,12 @@ router.post('/:id/import-setlist', authorize, adminCheck, async (req, res) => {
                 [id, songId, song.order || 1] // Fallback order if missing, but usually provided
             );
         }
+
+        // インポートしたらNORMALに自動更新
+        await db.query(
+            "UPDATE lives SET setlist_status = 'NORMAL' WHERE id = $1",
+            [id]
+        );
 
         await db.query("COMMIT");
         res.json({ message: "Setlist imported successfully", count: songs.length });

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -26,8 +26,10 @@ router.get('/', async (req, res) => {
             // 基本集計
             db.query(`
                 SELECT
-                    (SELECT COUNT(*)::int FROM lives WHERE date::date <= $1) as total_lives,
-                    (SELECT COUNT(*)::int FROM setlists sl JOIN lives l ON sl.live_id = l.id WHERE l.date::date <= $1) as total_songs_performed
+                    (SELECT COUNT(*)::int FROM lives
+                     WHERE date::date < $1 OR (date::date = $1 AND setlist_status = 'NORMAL')) as total_lives,
+                    (SELECT COUNT(*)::int FROM setlists sl JOIN lives l ON sl.live_id = l.id
+                     WHERE l.date::date < $1 OR (l.date::date = $1 AND l.setlist_status = 'NORMAL')) as total_songs_performed
             `, [today]),
 
             // 年別統計
@@ -39,25 +41,29 @@ router.get('/', async (req, res) => {
                     COUNT(DISTINCT sl.song_id)::int as unique_songs
                 FROM lives l
                 LEFT JOIN setlists sl ON l.id = sl.live_id
-                WHERE l.date::date <= $1
+                WHERE l.date::date < $1 OR (l.date::date = $1 AND l.setlist_status = 'NORMAL')
                 GROUP BY EXTRACT(YEAR FROM l.date)
                 ORDER BY year ASC
             `, [today]),
 
-            // 直近10件
+            // 直近10件（LatestLive候補）
+            // 過去日付 OR 当日でsetlist_status = 'NORMAL' の場合に表示
             db.query(`
-                SELECT id, tour_name, title, date::text, venue, type, prefecture, special_note
+                SELECT id, tour_name, title, date::text, venue, type, prefecture, special_note, setlist_status
                 FROM lives
-                WHERE date::date <= $1
+                WHERE date::date < $1
+                   OR (date::date = $1 AND setlist_status = 'NORMAL')
                 ORDER BY date DESC
                 LIMIT 10
             `, [today]),
 
-            // 今後のライブ
+            // 今後のライブ（NextLive候補）
+            // 未来日付 OR 当日でNORMAL未確定の場合に表示
             db.query(`
-                SELECT id, tour_name, title, date::text, venue, type, prefecture, special_note
+                SELECT id, tour_name, title, date::text, venue, type, prefecture, special_note, setlist_status
                 FROM lives
                 WHERE date::date > $1
+                   OR (date::date = $1 AND (setlist_status IS NULL OR setlist_status != 'NORMAL'))
                 ORDER BY date ASC
             `, [today]),
 
@@ -67,7 +73,7 @@ router.get('/', async (req, res) => {
                 FROM songs s
                 JOIN setlists sl ON s.id = sl.song_id
                 JOIN lives l ON sl.live_id = l.id
-                WHERE l.date::date <= $1
+                WHERE l.date::date < $1 OR (l.date::date = $1 AND l.setlist_status = 'NORMAL')
                 GROUP BY s.id, s.title, s.image_url
                 ORDER BY count DESC
             `, [today]),
@@ -81,7 +87,7 @@ router.get('/', async (req, res) => {
                     MAX(date)::text as end_date,
                     MAX(date)::text as latest_date
                 FROM lives
-                WHERE date::date <= $1
+                WHERE (date::date < $1 OR (date::date = $1 AND setlist_status = 'NORMAL'))
                     AND type NOT IN ('FESTIVAL', 'EVENT')
                     AND (
                         tour_name IS NULL
@@ -105,7 +111,7 @@ router.get('/', async (req, res) => {
                 FROM lives l
                 JOIN setlists sl ON l.id = sl.live_id
                 JOIN songs s ON sl.song_id = s.id
-                WHERE l.date::date <= $1
+                WHERE (l.date::date < $1 OR (l.date::date = $1 AND l.setlist_status = 'NORMAL'))
                     AND l.type NOT IN ('FESTIVAL', 'EVENT')
                     AND (
                         l.tour_name IS NULL

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -4,8 +4,10 @@ const { normalizeVenueName } = require('../utils/songTranslations');
 
 const formatDate = (dateStr) => {
     if (!dateStr) return '';
-    const d = new Date(dateStr.split('T')[0].replace(/-/g, '/'));
-    return d.toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\//g, '.');
+    // node:20-slim は ICU データが限定的なため toLocaleDateString は使わない
+    const [year, month, day] = dateStr.split('T')[0].split(' ')[0].split('-');
+    if (!year || !month || !day) return dateStr;
+    return `${year}.${month}.${day}`;
 };
 
 router.get('/', async (req, res) => {
@@ -181,7 +183,8 @@ router.get('/', async (req, res) => {
             songFrequencyMap
         });
     } catch (err) {
-        console.error('Stats API error:', err);
+        console.error('[/api/stats] Error:', err.message);
+        console.error(err.stack);
         res.status(500).json({ message: 'Server Error', error: err.message });
     }
 });


### PR DESCRIPTION
## 概要
LatestLive と NextLive の切り替えロジックを、単純な「今日の日付」ベースから、「セットリストが登録されているかどうか」ベースに変更しました。

## 変更内容
- **lives.js**: /api/lives/latest エンドポイントにおいて、セットリストが存在する直近のライブを返すように変更。
- **stats.js**: 日付フォーマットの安定化（ロケール依存の排除）。

## 理由
ライブ当日にセットリストがまだ登録されていない時間帯でも、前回のライブが『最新』として表示され続けることで、ユーザーが過去のセットリストにアクセスしやすくなります。