### PR TITLE
hotfix: ダッシュボード0件バグ修正（SQLパラメータ不一致）

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -111,14 +111,14 @@ router.get('/', async (req, res) => {
                 FROM lives l
                 JOIN setlists sl ON l.id = sl.live_id
                 JOIN songs s ON sl.song_id = s.id
-                WHERE l.setlist_status = 'NORMAL' OR EXISTS (SELECT 1 FROM setlists sl_sub WHERE sl_sub.live_id = l.id)
+                WHERE (l.setlist_status = 'NORMAL' OR EXISTS (SELECT 1 FROM setlists sl_sub WHERE sl_sub.live_id = l.id))
                     AND l.type NOT IN ('FESTIVAL', 'EVENT')
                     AND (
                         l.tour_name IS NULL
                         OR (UPPER(l.tour_name) NOT LIKE '%FES.%' AND UPPER(l.tour_name) NOT LIKE '%FESTIVAL%')
                     )
                 GROUP BY COALESCE(l.tour_name, l.title), s.title, s.id
-            `, [today])
+            `)
         ]);
 
         const basic = basicRes.rows[0];


### PR DESCRIPTION
## 問題

本番ダッシュボードでライブが表示されない（0件）。

## 原因

`server/routes/stats.js` のツアー楽曲クエリに2つのSQLバグ。

**① パラメータ不一致（致命的）**
```sql
-- SQL に $1 がないのに [today] を渡している → PostgreSQL エラー
GROUP BY COALESCE(l.tour_name, l.title), s.title, s.id
`, [today])  ← ここが不要
```

**② OR/AND 演算子の優先順位バグ**
```sql
-- 修正前（フェスがツアーに混入）
WHERE l.setlist_status = 'NORMAL' OR EXISTS (...) AND l.type NOT IN (...)
-- 修正後
WHERE (l.setlist_status = 'NORMAL' OR EXISTS (...)) AND l.type NOT IN (...)
```

## 修正

- `[today]` パラメータを削除
- OR条件を括弧で囲み演算子優先度を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)