### PR TITLE
feat: ライブデータ正規化用カラムの追加マイグレーション

### DIFF
--- a/scripts/sync/init_existing_data.cjs
+++ b/scripts/sync/init_existing_data.cjs
@@ -22,7 +22,7 @@ async function init() {
     await client.connect();
 
     try {
-        const res = await client.query('SELECT id, date, title, venue, tour_name, is_manually_edited, source FROM lives');
+        const res = await client.query('SELECT id, date, title, venue, tour_name FROM lives');
         console.log(`Processing ${res.rows.length} existing records...`);
 
         for (const row of res.rows) {

--- a/server/migrations/021_add_normalization_columns.sql
+++ b/server/migrations/021_add_normalization_columns.sql
@@ -1,0 +1,17 @@
+-- livesテーブルの正規化カラム追加 (V4)
+ALTER TABLE lives ADD COLUMN IF NOT EXISTS normalized_tour_name TEXT;
+ALTER TABLE lives ADD COLUMN IF NOT EXISTS normalized_title TEXT;
+ALTER TABLE lives ADD COLUMN IF NOT EXISTS normalized_venue TEXT;
+ALTER TABLE lives ADD COLUMN IF NOT EXISTS external_source_id TEXT;
+ALTER TABLE lives ADD COLUMN IF NOT EXISTS normalization_version TEXT;
+
+-- 検索を高速化するためのインデックス
+CREATE INDEX IF NOT EXISTS idx_lives_normalized_tour_name ON lives (normalized_tour_name);
+CREATE INDEX IF NOT EXISTS idx_lives_external_source_id ON lives (external_source_id);
+
+-- 説明文の追加
+COMMENT ON COLUMN lives.normalized_tour_name IS '正規化されたツアー名（検索・重複排除用）';
+COMMENT ON COLUMN lives.normalized_title IS '正規化されたライブタイトル';
+COMMENT ON COLUMN lives.normalized_venue IS '正規化された会場名';
+COMMENT ON COLUMN lives.external_source_id IS '外部ソースとの紐付け用の一意なハッシュID';
+COMMENT ON COLUMN lives.normalization_version IS '正規化に使用したロジックのバージョン';


### PR DESCRIPTION
### 概要
前回のデプロイで不足していた、ライブデータの正規化および外部ID保存用のカラムを追加するマイグレーション（021）を追加しました。

### 変更点
- lives テーブルに以下のカラムを追加：
  - 
ormalized_tour_name
  - 
ormalized_title
  - 
ormalized_venue
  - external_source_id
  - 
ormalization_version
- 検索最適化のためのインデックス追加。

### 影響
このマイグレーションを適用することで、scripts/sync/init_existing_data.cjs が正常に動作するようになります。