### PR TITLE
fix: Safari日付バグ修正・ライブアーカイブ機能追加・ダッシュボード改善

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -148,7 +148,7 @@ router.get('/', async (req, res) => {
             tourSongMap[tourName].push({
                 title: row.song_title,
                 count: row.count,
-                lives: row.lives.map(l => ({ ...l, date: formatDate(l.date) })),
+                lives: row.lives,
                 percentage: ((row.count / liveCount) * 100).toFixed(1)
             });
         });

--- a/src/lib/normalizers/dataNormalizer.ts
+++ b/src/lib/normalizers/dataNormalizer.ts
@@ -92,7 +92,11 @@ export function normalizeSong(raw: any): Song {
  */
 export function safeDate(dateStr: any): string {
     if (!dateStr) return new Date().toISOString();
-    const d = new Date(dateStr);
+    // Safari は YYYY.MM.DD や "YYYY-MM-DD HH:MM:SS" を拒否する。ISO 8601 に正規化する
+    const normalized = typeof dateStr === 'string'
+        ? dateStr.replace(/\./g, '-').replace(' ', 'T')
+        : dateStr;
+    const d = new Date(normalized);
     if (isNaN(d.getTime())) {
         console.warn(`[Normalization] Invalid date string: ${dateStr}`);
         return new Date().toISOString();

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -729,7 +729,6 @@ function Dashboard() {
                                 <>
                                     <div style={{ color: '#888', marginBottom: '20px', display: 'flex', justifyContent: 'space-between' }}>
                                         <span>{modalFilter.value.liveCount} Shows / {modalFilter.value.totalSongs} Songs</span>
-                                        <span>{modalFilter.value.startDate} 〜 {modalFilter.value.endDate}</span>
                                     </div>
 
                                     <div>


### PR DESCRIPTION
## 概要

- Safari（iOS/モバイル）でツアーハイライトの日付が今日の日付になるバグを修正
- LIVE ARCHIVEページに検索・絞り込み・会場表示機能を追加
- ダッシュボードの日付表示修正（ISO文字列の正しいパース）
- その他バグ修正・リファクタリング

## 主な変更

### バグ修正
- **Safari日付バグ**: stats.js が YYYY.MM.DD 形式で返していた日付を Safari が Invalid Date として拒否し、今日の日付を表示していた問題を修正
- safeDate に ISO 8601 正規化処理を追加（Safari 対応強化）
- ダッシュボード Recent Lives の日付表示を ISO 文字列から正しくパースするよう修正
- SongsByAlbum モーダルの不正な日付範囲表示（固定値）を削除
- 演奏履歴の日付表示を日本語形式に修正

### 新機能
- LIVE ARCHIVE ページに検索バー・ライブタイプ絞り込み・楽曲絞り込みフィルターを追加
- ライブカードに会場列を追加（デスクトップ表示）
- ライブカードのツアー名をメイン、タイトルをサブテキストとして表示

### その他
- リポジトリ public 化対応（内部 IP・ユーザー名のマスク）
- ライブ同期システム V3 への拡張
- YouTube/Spotify OAuth 連携の堅牢化

## 確認ポイント
- [ ] モバイル（Safari）でダッシュボードのツアーハイライト日付が正しく表示される
- [ ] LIVE ARCHIVEページの検索・絞り込みが動作する
- [ ] ダッシュボードの Recent Lives 日付が正しく表示される

Generated with Claude Code