### PR TITLE
feat: セキュリティ強化 - CORS制限・CSP・users論理削除 (#115/#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+.agent/temp/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,6 +3,7 @@
 
 # Security
 # JWT_SECRET=your_complex_secret_key
+# ALLOWED_ORIGINS=https://uver-setlist-archive.org  ← 本番: ドメインを制限 / ローカル: 未設定で全許可
 
 # External APIs
 SETLIST_FM_API_KEY=your_setlist_fm_api_key_here

--- a/server/index.js
+++ b/server/index.js
@@ -16,11 +16,38 @@ if (!process.env.JWT_SECRET) {
     process.exit(1);
 }
 
-// Middleware (Unified for all environments to ensure consistency)
-app.use(helmet({
-    contentSecurityPolicy: false,
+// CORS: ALLOWED_ORIGINS 環境変数でドメインを制限（未設定時は全許可）
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
+    : null;
+
+app.use(cors({
+    origin: allowedOrigins
+        ? (origin, callback) => {
+            if (!origin || allowedOrigins.includes(origin)) return callback(null, true);
+            callback(new Error('CORS policy violation'));
+          }
+        : true,
+    credentials: true,
 }));
-app.use(cors());
+
+// CSP: Google Fonts・Spotify・YouTube を許可しつつスクリプト注入を防止
+app.use(helmet({
+    contentSecurityPolicy: {
+        directives: {
+            defaultSrc:     ["'self'"],
+            scriptSrc:      ["'self'"],
+            styleSrc:       ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+            fontSrc:        ["'self'", 'https://fonts.gstatic.com'],
+            imgSrc:         ["'self'", 'data:', 'https:'],
+            connectSrc:     ["'self'", 'https://api.spotify.com', 'https://accounts.spotify.com', 'https://api.setlist.fm'],
+            frameSrc:       ['https://www.youtube.com', 'https://open.spotify.com'],
+            objectSrc:      ["'none'"],
+            baseUri:        ["'self'"],
+        },
+    },
+}));
+
 app.use(express.json());
 
 // Request logging middleware

--- a/server/migrations/024_users_soft_delete.sql
+++ b/server/migrations/024_users_soft_delete.sql
@@ -1,0 +1,11 @@
+-- users テーブルに論理削除カラムを追加（Issue #115 / #113）
+--
+-- 背景:
+--   退会時に物理削除を廃止し、corrections など知識データへの参照を匿名化して保持する。
+--   30日間は deleted_at をクリアすれば復元可能。
+--   ログイン時に deleted_at IS NULL チェックを追加することで
+--   論理削除済みユーザーの再ログインを防ぐ。
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX IF NOT EXISTS idx_users_deleted_at ON users (deleted_at) WHERE deleted_at IS NOT NULL;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -86,7 +86,7 @@ router.post('/verify-email', async (req, res) => {
 router.post('/login', loginLimiter, async (req, res) => {
     try {
         const { email, password } = req.body;
-        const user = await db.query("SELECT * FROM users WHERE email = $1", [email]);
+        const user = await db.query("SELECT * FROM users WHERE email = $1 AND deleted_at IS NULL", [email]);
 
         if (user.rows.length === 0) {
             // Log failed login attempt - user not found

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -17,8 +17,9 @@ const getOptionalUserId = (req) => {
 // GET all users (Protected: Admin Only)
 router.get('/', authorize, adminCheck, async (req, res) => {
     try {
-        // Fetch all users
-        const allUsers = await db.query("SELECT id, username, email, created_at, role FROM users ORDER BY created_at DESC");
+        const allUsers = await db.query(
+            "SELECT id, username, email, created_at, role, deleted_at FROM users ORDER BY created_at DESC"
+        );
         res.json(allUsers.rows);
     } catch (err) {
         console.error(err.message);
@@ -54,24 +55,45 @@ router.put('/:id/role', authorize, adminCheck, async (req, res) => {
     }
 });
 
-// DELETE User (Admin only)
+// DELETE User (Admin only) — 論理削除
 router.delete('/:id', authorize, adminCheck, async (req, res) => {
     try {
         const currentUserId = req.user.user_id;
         const targetUserId = req.params.id;
 
-        // Prevent deleting yourself
         if (currentUserId == targetUserId) {
             return res.status(400).json("Cannot delete yourself");
         }
 
-        const deleteUser = await db.query("DELETE FROM users WHERE id = $1", [targetUserId]);
+        const result = await db.query(
+            "UPDATE users SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL RETURNING id",
+            [targetUserId]
+        );
 
-        if (deleteUser.rowCount === 0) {
-            return res.json("User not found");
+        if (result.rowCount === 0) {
+            return res.json("User not found or already deleted");
         }
 
         res.json("User deleted");
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send("Server Error");
+    }
+});
+
+// PATCH Restore User (Admin only) — 論理削除を解除
+router.patch('/:id/restore', authorize, adminCheck, async (req, res) => {
+    try {
+        const result = await db.query(
+            "UPDATE users SET deleted_at = NULL WHERE id = $1 AND deleted_at IS NOT NULL RETURNING id, username, email, role",
+            [req.params.id]
+        );
+
+        if (result.rowCount === 0) {
+            return res.status(404).json("User not found or not deleted");
+        }
+
+        res.json(result.rows[0]);
     } catch (err) {
         console.error(err.message);
         res.status(500).send("Server Error");
@@ -311,7 +333,7 @@ router.get('/:id/profile', async (req, res) => {
                     )
                 END AS is_following
             FROM users u
-            WHERE u.id = $1
+            WHERE u.id = $1 AND u.deleted_at IS NULL
         `, [userId, currentUserId]);
 
         if (result.rows.length === 0) {
@@ -335,7 +357,7 @@ router.get('/:id/attended_lives', async (req, res) => {
 
     try {
         const userCheck = await db.query(
-            'SELECT is_public FROM users WHERE id = $1', [userId]
+            'SELECT is_public FROM users WHERE id = $1 AND deleted_at IS NULL', [userId]
         );
         if (userCheck.rows.length === 0) {
             return res.status(404).json({ message: 'ユーザーが見つかりません' });
@@ -419,15 +441,17 @@ router.get('/:id/predictions', async (req, res) => {
     }
 });
 
-// DELETE current user account
+// DELETE current user account — 論理削除（30日後に完全削除を想定）
 router.delete('/me', authorize, async (req, res) => {
     try {
         const currentUserId = req.user.user_id;
 
-        // attendance records will be deleted automatically due to ON DELETE CASCADE
-        const deleteResult = await db.query("DELETE FROM users WHERE id = $1", [currentUserId]);
+        const result = await db.query(
+            "UPDATE users SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL RETURNING id",
+            [currentUserId]
+        );
 
-        if (deleteResult.rowCount === 0) {
+        if (result.rowCount === 0) {
             return res.status(404).json("User not found");
         }
 

--- a/src/components/Admin/tabs/AdminUsersTab.tsx
+++ b/src/components/Admin/tabs/AdminUsersTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
-import { Loader, ArrowUpDown, Trash2, ShieldAlert, Search } from 'lucide-react';
+import { Loader, ArrowUpDown, Trash2, ShieldAlert, Search, RotateCcw } from 'lucide-react';
 import { useAuth } from '../../../contexts/AuthContext';
-import { useAdminUsers, useDeleteUser, useUpdateUserRole } from '../../../hooks/queries/useAdminUsers';
+import { useAdminUsers, useDeleteUser, useUpdateUserRole, useRestoreUser } from '../../../hooks/queries/useAdminUsers';
 import type { User } from '../../../types/api';
 import { X } from 'lucide-react';
 
@@ -10,8 +10,10 @@ const AdminUsersTab = () => {
     const { data: users = [], isLoading } = useAdminUsers();
     const deleteUser = useDeleteUser();
     const updateRole = useUpdateUserRole();
+    const restoreUser = useRestoreUser();
 
     const [searchTerm, setSearchTerm] = useState('');
+    const [showDeleted, setShowDeleted] = useState(false);
     const [sortConfig, setSortConfig] = useState({ key: 'created_at', direction: 'desc' });
 
     const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -25,6 +27,7 @@ const AdminUsersTab = () => {
 
     const processed = useMemo(() => {
         let items = [...users];
+        if (!showDeleted) items = items.filter(u => !u.deleted_at);
         if (searchTerm) {
             const lower = searchTerm.toLowerCase();
             items = items.filter(u => u.username.toLowerCase().includes(lower) || u.email.toLowerCase().includes(lower));
@@ -45,9 +48,18 @@ const AdminUsersTab = () => {
             await deleteUser.mutateAsync(userToDelete.id);
             setShowDeleteModal(false);
             setUserToDelete(null);
-            alert('ユーザーを削除しました。');
+            alert('ユーザーを削除しました（論理削除）。');
         } catch (err) {
             alert(`削除に失敗しました: ${(err as any).data?.message || (err as any).message}`);
+        }
+    };
+
+    const handleRestore = async (user: User) => {
+        try {
+            await restoreUser.mutateAsync(user.id);
+            alert(`${user.username} を復元しました。`);
+        } catch (err) {
+            alert(`復元に失敗しました: ${(err as any).data?.message || (err as any).message}`);
         }
     };
 
@@ -73,14 +85,23 @@ const AdminUsersTab = () => {
     return (
         <div className="tab-content fade-in">
             <div className="table-header-panel">
-                <h3>Registered Users</h3>
-                <div style={{ position: 'relative' }}>
-                    <Search size={16} className="search-icon" />
-                    <input
-                        type="text" placeholder="Search users..."
-                        value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)}
-                        className="search-input"
-                    />
+                <h3>Registered Users ({processed.length}{showDeleted && ` / 削除済み ${users.filter(u => u.deleted_at).length}件`})</h3>
+                <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+                    <div style={{ position: 'relative' }}>
+                        <Search size={16} className="search-icon" />
+                        <input
+                            type="text" placeholder="Search users..."
+                            value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)}
+                            className="search-input"
+                        />
+                    </div>
+                    <button
+                        onClick={() => setShowDeleted(v => !v)}
+                        style={{ padding: '6px 12px', fontSize: '0.75rem', borderRadius: '6px', cursor: 'pointer', border: '1px solid', borderColor: showDeleted ? '#ef4444' : '#334155', background: showDeleted ? 'rgba(239,68,68,0.15)' : '#0f172a', color: showDeleted ? '#ef4444' : '#94a3b8' }}
+                    >
+                        <Trash2 size={14} style={{ display: 'inline', marginRight: '4px' }} />
+                        {showDeleted ? '削除済みを隠す' : '削除済みを表示'}
+                    </button>
                 </div>
             </div>
             <div className="table-container">
@@ -96,34 +117,45 @@ const AdminUsersTab = () => {
                         </tr>
                     </thead>
                     <tbody>
-                        {processed.map(user => (
-                            <tr key={user.id}>
-                                <td style={{ width: '60px' }}>#{user.id}</td>
-                                <td style={{ fontWeight: 'bold' }}>{user.username}</td>
-                                <td style={{ color: '#cbd5e1' }}>{user.email}</td>
-                                <td style={{ width: '100px' }}><span className={`role-badge ${user.role}`}>{user.role}</span></td>
-                                <td style={{ color: '#94a3b8', width: '120px' }}>{new Date(user.created_at).toLocaleDateString()}</td>
-                                <td style={{ width: '120px' }}>
-                                    <div className="actions-wrapper">
-                                        <button
-                                            onClick={() => { setUserToUpdate(user); setShowRoleModal(true); }}
-                                            className="action-btn promote"
-                                            title="Update Role"
-                                        >
-                                            <ShieldAlert size={18} />
-                                        </button>
-                                        <button
-                                            onClick={() => { setUserToDelete(user); setShowDeleteModal(true); }}
-                                            disabled={!!(currentUser && user.id === currentUser.id)}
-                                            className={`action-btn delete ${currentUser && user.id === currentUser.id ? 'disabled' : ''}`}
-                                            title="Delete"
-                                        >
-                                            <Trash2 size={18} />
-                                        </button>
-                                    </div>
-                                </td>
-                            </tr>
-                        ))}
+                        {processed.map(user => {
+                            const isDeleted = !!user.deleted_at;
+                            return (
+                                <tr key={user.id} style={isDeleted ? { opacity: 0.45 } : undefined}>
+                                    <td style={{ width: '60px' }}>#{user.id}</td>
+                                    <td style={{ fontWeight: 'bold', textDecoration: isDeleted ? 'line-through' : undefined, color: isDeleted ? '#ef4444' : undefined }}>{user.username}</td>
+                                    <td style={{ color: '#cbd5e1' }}>{user.email}</td>
+                                    <td style={{ width: '100px' }}><span className={`role-badge ${user.role}`}>{user.role}</span></td>
+                                    <td style={{ color: '#94a3b8', width: '120px' }}>{new Date(user.created_at).toLocaleDateString()}</td>
+                                    <td style={{ width: '120px' }}>
+                                        <div className="actions-wrapper">
+                                            {isDeleted ? (
+                                                <button onClick={() => handleRestore(user)} className="action-btn" title="Restore" style={{ color: '#34d399' }}>
+                                                    <RotateCcw size={18} />
+                                                </button>
+                                            ) : (
+                                                <>
+                                                    <button
+                                                        onClick={() => { setUserToUpdate(user); setShowRoleModal(true); }}
+                                                        className="action-btn promote"
+                                                        title="Update Role"
+                                                    >
+                                                        <ShieldAlert size={18} />
+                                                    </button>
+                                                    <button
+                                                        onClick={() => { setUserToDelete(user); setShowDeleteModal(true); }}
+                                                        disabled={!!(currentUser && user.id === currentUser.id)}
+                                                        className={`action-btn delete ${currentUser && user.id === currentUser.id ? 'disabled' : ''}`}
+                                                        title="Delete"
+                                                    >
+                                                        <Trash2 size={18} />
+                                                    </button>
+                                                </>
+                                            )}
+                                        </div>
+                                    </td>
+                                </tr>
+                            );
+                        })}
                     </tbody>
                 </table>
             </div>
@@ -177,7 +209,7 @@ const AdminUsersTab = () => {
                                 <p style={{ color: '#94a3b8', marginBottom: '5px' }}>
                                     <strong>{userToDelete.username}</strong> ({userToDelete.email})
                                 </p>
-                                <p style={{ color: '#ef4444', fontSize: '0.9rem' }}>この操作は取り消せません。</p>
+                                <p style={{ color: '#fbbf24', fontSize: '0.9rem' }}>論理削除されます（復元可能）。</p>
                             </div>
                             <div className="form-actions">
                                 <button type="button" className="btn-secondary" onClick={() => setShowDeleteModal(false)}>キャンセル</button>

--- a/src/hooks/queries/useAdminUsers.ts
+++ b/src/hooks/queries/useAdminUsers.ts
@@ -29,3 +29,13 @@ export const useUpdateUserRole = () => {
     },
   })
 }
+
+export const useRestoreUser = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (userId: number) => apiClient.patch(`/api/users/${userId}/restore`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users })
+    },
+  })
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -80,6 +80,7 @@ export interface User {
   email_verified: boolean
   created_at: string
   is_public?: boolean
+  deleted_at?: string | null
 }
 
 // 認証済みユーザー（AuthContext）


### PR DESCRIPTION
## 概要

Issue #115 / #113 対応。本番稼働に向けたセキュリティ強化とユーザー削除フローの健全化。

## 変更内容

### CORS ドメイン制限
- `ALLOWED_ORIGINS` 環境変数でアクセス許可ドメインを制限
- 未設定時は全許可（ローカル開発の後方互換を維持）
- 本番 `.env` に `ALLOWED_ORIGINS=https://uver-setlist-archive.org` を追加すること

### CSP (Content Security Policy) 有効化
- Helmet の `contentSecurityPolicy: false` を解除
- Google Fonts / Spotify API / YouTube iframe を許可リストに追加
- `script-src 'self'` でスクリプト注入攻撃を防止

### users 論理削除（Soft Delete）
- migration 024: `users` テーブルに `deleted_at` カラムを追加
- ログイン時に `deleted_at IS NULL` を確認 → 退会済みユーザーのログインを防止
- `DELETE /me`: 物理削除 → `deleted_at = NOW()` に変更（30日後に完全削除を想定）
- `DELETE /api/users/:id` (管理者): 同様に論理削除へ変更
- `PATCH /api/users/:id/restore` (管理者): 論理削除を解除するエンドポイントを追加
- 公開プロフィール・参戦ライブ API で `deleted_at IS NULL` フィルタを追加

### 管理画面 Users タブ
- 「削除済みを表示」トグルを追加
- 削除済みユーザーは取り消し線 + 薄い表示
- 復元ボタン（RotateCcw アイコン）を追加

## 本番反映時の追加作業

**本番サーバーの `.env` に以下を追加すること:**
```
ALLOWED_ORIGINS=https://uver-setlist-archive.org
```

## スコープ外（中長期）

- JWT HttpOnly Cookie 移行（Issue #115 に「中長期」と明記）

## テスト計画

- [ ] ログイン / 新規登録が正常に動作すること
- [ ] 管理画面 > Users タブで削除 → 論理削除されること（復元可能）
- [ ] 「削除済みを表示」トグルで削除済みユーザーが表示される
- [ ] 削除済みユーザーの復元ボタンが動作する
- [ ] 削除済みユーザーのプロフィールページが 404 を返す
- [ ] CSP ヘッダーが付与されていること（DevTools > Network > Response Headers で確認）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
