### PR TITLE
feat: 演奏推移チャート追加 ＆ fix: Admin Statsバグ修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# UVERworld Setlist Archive
+
+UVERworld ファンのライブ参戦記録・セットリスト管理サイト。
+
+## 技術スタック
+
+| 層 | 技術 |
+|---|---|
+| フロントエンド | React 19 + Vite + TanStack React Query + TypeScript (一部) |
+| バックエンド | Node.js / Express 5（`server/`） |
+| DB | PostgreSQL（`server/db.js`） |
+| 認証 | JWT + bcrypt |
+
+## 開発サーバー起動
+
+```powershell
+# フロントエンド（プロジェクトルートで）
+npm run dev
+
+# バックエンド（別ターミナルで）
+cd server && npm run dev
+```
+
+Vite は `/api/*` を `http://127.0.0.1:3001` にプロキシします（`vite.config.js`）。  
+**バックエンドのデフォルトポートは `server/.env` の `PORT` に依存します。ローカルでは `3001` に設定してください。**
+
+## ブランチ・デプロイ戦略
+
+```
+feature/* → dev（push で Staging 自動デプロイ）→ main（GitHub Release で Production 自動デプロイ）
+```
+
+- `dev` push → Docker Compose ベースの Staging へ自動デプロイ
+- GitHub Release publish → systemd ベースの Production へ自動デプロイ（`deploy-production.yml`）
+
+## 重要なルール
+
+- 本番DBへの直接操作は禁止。スキーマ変更は `server/scripts/` のマイグレーションスクリプトで行う。
+- `main` ブランチへのマージだけでは本番デプロイされない。**必ず GitHub Release を publish する。**
+- 本番デプロイ後は `sudo systemctl status uver-setlist` で起動時刻を確認する（ゾンビプロセス対策）。
+
+## テスト
+
+```powershell
+npm test        # vitest（フロントエンド）
+```
+
+## 詳細ドキュメント
+
+@docs/development_workflow.md
+@docs/environments.md
+@docs/SPECIFICATIONS.md
+@docs/db_operations.md
+@docs/social_post_playbook.md

--- a/server/routes/songs.js
+++ b/server/routes/songs.js
@@ -197,6 +197,166 @@ router.get('/:id/stats', async (req, res) => {
     }
 });
 
+// GET 楽曲演奏推移タイムライン（年別集計）
+router.get('/:id/performance-timeline', async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        // IDまたはタイトルで楽曲を特定する
+        const isNumericId = /^\d+$/.test(id);
+        const searchParam = isNumericId
+            ? id
+            : id.replace(/\s+/g, '').toLowerCase();
+
+        const songLookupQuery = isNumericId
+            ? 'SELECT id FROM songs WHERE id = $1 AND deleted_at IS NULL'
+            : "SELECT id FROM songs WHERE REPLACE(LOWER(title), ' ', '') = $1 AND deleted_at IS NULL";
+
+        const songResult = await db.query(songLookupQuery, [searchParam]);
+        if (songResult.rows.length === 0) {
+            return res.status(404).json({ message: 'Song not found' });
+        }
+        const songId = songResult.rows[0].id;
+
+        // 年別演奏回数・ツアー名を集計（NULL tour_name を除外、安全な ARRAY サブクエリを使用）
+        const yearlyResult = await db.query(`
+            SELECT
+              EXTRACT(YEAR FROM l.date)::int AS year,
+              COUNT(DISTINCT l.id)::int AS count,
+              ARRAY(
+                SELECT DISTINCT t
+                FROM unnest(
+                  ARRAY_AGG(l.tour_name) FILTER (WHERE l.tour_name IS NOT NULL)
+                ) t
+                ORDER BY t
+              ) AS tours
+            FROM setlists sl
+            JOIN lives l ON sl.live_id = l.id
+            WHERE sl.song_id = $1
+              AND l.date <= CURRENT_DATE
+            GROUP BY EXTRACT(YEAR FROM l.date)
+            ORDER BY year ASC
+        `, [songId]);
+
+        // 初披露・最終披露日を取得
+        const metaResult = await db.query(`
+            SELECT
+              MIN(l.date) AS first_performed_at,
+              MAX(l.date) AS last_performed_at
+            FROM setlists sl
+            JOIN lives l ON sl.live_id = l.id
+            WHERE sl.song_id = $1
+              AND l.date <= CURRENT_DATE
+        `, [songId]);
+
+        const meta = metaResult.rows[0];
+        const firstPerformedAt = meta.first_performed_at
+            ? new Date(meta.first_performed_at).toISOString().slice(0, 10)
+            : null;
+        const lastPerformedAt = meta.last_performed_at
+            ? new Date(meta.last_performed_at).toISOString().slice(0, 10)
+            : null;
+
+        // 演奏があった全ライブ日付（昇順）を取得してサーバー側で longestGap を計算
+        const datesResult = await db.query(`
+            SELECT DISTINCT l.date
+            FROM setlists sl
+            JOIN lives l ON sl.live_id = l.id
+            WHERE sl.song_id = $1
+              AND l.date <= CURRENT_DATE
+            ORDER BY l.date ASC
+        `, [songId]);
+
+        const performanceDates = datesResult.rows.map(r => new Date(r.date));
+
+        // longestGap: 連続する披露日の差分の最大値（「その曲が演奏されなかった期間」）
+        let longestGapDays = null;
+        let longestGapStart = null;
+        let longestGapEnd = null;
+
+        for (let i = 1; i < performanceDates.length; i++) {
+            const gapDays = Math.floor(
+                (performanceDates[i] - performanceDates[i - 1]) / (1000 * 60 * 60 * 24)
+            );
+            if (longestGapDays === null || gapDays > longestGapDays) {
+                longestGapDays = gapDays;
+                longestGapStart = performanceDates[i - 1].toISOString().slice(0, 10);
+                longestGapEnd = performanceDates[i].toISOString().slice(0, 10);
+            }
+        }
+
+        // currentGapDays: 最後の披露日から今日まで（負数ガード）
+        const currentGapDays = lastPerformedAt
+            ? Math.max(0, Math.floor(
+                (new Date() - new Date(lastPerformedAt)) / (1000 * 60 * 60 * 24)
+              ))
+            : null;
+
+        // 年別データを構築し欠番補完（MIN_YEAR: 2000、MAX_YEAR: 現在年）
+        const MIN_YEAR = 2000;
+        const MAX_YEAR = new Date().getFullYear();
+        const startYear = firstPerformedAt
+            ? Math.max(MIN_YEAR, parseInt(firstPerformedAt.slice(0, 4)))
+            : MIN_YEAR;
+
+        const yearMap = {};
+        for (const row of yearlyResult.rows) {
+            yearMap[row.year] = { count: row.count, tours: row.tours };
+        }
+
+        // ツアー名は5件まで表示、tourLabel は API 側で生成（Tooltip のパフォーマンス最適化）
+        const yearlyData = [];
+        for (let y = startYear; y <= MAX_YEAR; y++) {
+            const entry = yearMap[y] ?? { count: 0, tours: [] };
+            const tours = (entry.tours ?? []).slice(0, 5);
+            const hasMoreTours = (entry.tours ?? []).length > 5;
+            const tourLabel = tours.join(' / ') + (hasMoreTours ? '…他' : '');
+            yearlyData.push({ year: y, count: entry.count, tours, hasMoreTours, tourLabel });
+        }
+
+        // 演奏密度メタデータを計算
+        const totalPerformances = yearlyData.reduce((sum, y) => sum + y.count, 0);
+        const activeYears = yearlyData.filter(y => y.count > 0);
+        const peakEntry = activeYears.reduce(
+            (max, y) => (y.count > (max?.count ?? 0) ? y : max),
+            null
+        );
+        const avgYearlyCount = activeYears.length > 0
+            ? parseFloat((totalPerformances / activeYears.length).toFixed(1))
+            : 0;
+
+        // 連続披露年数: 最長の連続する演奏あり年の長さ
+        let consecutiveYears = 0;
+        let currentStreak = 0;
+        for (const y of yearlyData) {
+            if (y.count > 0) {
+                currentStreak++;
+                consecutiveYears = Math.max(consecutiveYears, currentStreak);
+            } else {
+                currentStreak = 0;
+            }
+        }
+
+        res.json({
+            totalPerformances,
+            firstPerformedAt,
+            lastPerformedAt,
+            longestGapDays,
+            longestGapStart,
+            longestGapEnd,
+            currentGapDays,
+            peakYear: peakEntry?.year ?? null,
+            peakCount: peakEntry?.count ?? null,
+            avgYearlyCount,
+            consecutiveYears: consecutiveYears > 0 ? consecutiveYears : null,
+            yearlyData,
+        });
+    } catch (err) {
+        console.error('[performance-timeline] Error:', err.message);
+        res.status(500).json({ message: 'Server Error', error: err.message });
+    }
+});
+
 // CREATE a Song (Admin only)
 router.post('/', authorize, adminCheck, async (req, res) => {
     try {

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -199,6 +199,15 @@ router.get('/', async (req, res) => {
 // 管理者向けKPI統計
 router.get('/admin', authorize, adminCheck, async (req, res) => {
     try {
+        const queryWithFallback = async (queryStr, fallbackRows) => {
+            try {
+                return await db.query(queryStr);
+            } catch (err) {
+                console.error(`[STATS/ADMIN] Query failed:`, err.message);
+                return { rows: fallbackRows };
+            }
+        };
+
         const [
             userStatsRes,
             predictionStatsRes,
@@ -209,7 +218,7 @@ router.get('/admin', authorize, adminCheck, async (req, res) => {
             dailyPredictionsRes,
         ] = await Promise.all([
             // ユーザー統計
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     COUNT(*)::int                                                          AS total_users,
                     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days')::int AS new_users_30d,
@@ -217,42 +226,47 @@ router.get('/admin', authorize, adminCheck, async (req, res) => {
                     COUNT(*) FILTER (WHERE is_public = true)::int                         AS public_users
                 FROM users
                 WHERE deleted_at IS NULL
-            `),
+            `, [{ total_users: 0, new_users_30d: 0, new_users_7d: 0, public_users: 0 }]),
+
             // 予想統計
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     COUNT(*)::int                                                          AS total_predictions,
                     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days')::int AS new_predictions_30d,
                     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days')::int  AS new_predictions_7d,
                     COUNT(DISTINCT user_id)::int                                           AS users_with_predictions
                 FROM predictions
-            `),
+            `, [{ total_predictions: 0, new_predictions_30d: 0, new_predictions_7d: 0, users_with_predictions: 0 }]),
+
             // 参戦記録統計
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     COUNT(*)::int                                                          AS total_attendance,
                     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days')::int AS new_attendance_30d,
                     COUNT(DISTINCT user_id)::int                                           AS users_with_attendance
                 FROM attendance
-            `),
+            `, [{ total_attendance: 0, new_attendance_30d: 0, users_with_attendance: 0 }]),
+
             // アクティブユーザー（ログイン成功ベース）
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     COUNT(DISTINCT user_email) FILTER (WHERE timestamp >= NOW() - INTERVAL '7 days')::int  AS active_7d,
                     COUNT(DISTINCT user_email) FILTER (WHERE timestamp >= NOW() - INTERVAL '30 days')::int AS active_30d
                 FROM security_logs
                 WHERE event_type = 'login_success'
-            `),
+            `, [{ active_7d: 0, active_30d: 0 }]),
+
             // 修正依頼統計
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     COUNT(*)::int                                              AS total_corrections,
                     COUNT(*) FILTER (WHERE status = 'pending')::int           AS pending_corrections,
                     COUNT(*) FILTER (WHERE status = 'resolved')::int          AS resolved_corrections
                 FROM corrections
-            `),
+            `, [{ total_corrections: 0, pending_corrections: 0, resolved_corrections: 0 }]),
+
             // 直近30日の日別新規ユーザー数
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     DATE(created_at)::text AS date,
                     COUNT(*)::int          AS count
@@ -261,9 +275,10 @@ router.get('/admin', authorize, adminCheck, async (req, res) => {
                   AND deleted_at IS NULL
                 GROUP BY DATE(created_at)
                 ORDER BY date ASC
-            `),
+            `, []),
+
             // 直近30日の日別予想投稿数
-            db.query(`
+            queryWithFallback(`
                 SELECT
                     DATE(created_at)::text AS date,
                     COUNT(*)::int          AS count
@@ -271,7 +286,7 @@ router.get('/admin', authorize, adminCheck, async (req, res) => {
                 WHERE created_at >= NOW() - INTERVAL '30 days'
                 GROUP BY DATE(created_at)
                 ORDER BY date ASC
-            `),
+            `, [])
         ]);
 
         res.json({

--- a/src/components/Visual/SongYearlyPerformanceChart.tsx
+++ b/src/components/Visual/SongYearlyPerformanceChart.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+} from 'recharts';
+import { TrendingUp, Calendar, Clock, Zap } from 'lucide-react';
+import { useSongPerformanceTimeline } from '../../hooks/queries/useSongPerformanceTimeline';
+import type { YearlyPerformanceEntry } from '../../types/api';
+
+// ============================================================
+// 型定義
+// ============================================================
+interface Props {
+  /** 楽曲 ID またはタイトルスラッグ */
+  songId: string | number | undefined;
+}
+
+// ============================================================
+// ユーティリティ
+// ============================================================
+
+/**
+ * 演奏回数に応じたバー色を返す（対数スケール）
+ * 線形補間だと CORE PRIDE (150回) vs レア曲 (2回) で
+ * 低頻度年のバーが潰れるため対数スケールを採用
+ */
+const getBarColor = (count: number, maxCount: number): string => {
+  if (count === 0 || maxCount === 0) return '#1e293b'; // slate-900（0件）
+  const ratio = Math.log(count + 1) / Math.log(maxCount + 1);
+  // slate-600 (#475569) → blue-500 (#3b82f6) へのグラデーション
+  const r = Math.round(71  + ratio * (59  - 71));
+  const g = Math.round(85  + ratio * (130 - 85));
+  const b = Math.round(105 + ratio * (246 - 105));
+  return `rgb(${r}, ${g}, ${b})`;
+};
+
+/**
+ * 日数を「○年○ヶ月」形式にフォーマット
+ */
+const formatDays = (days: number): string => {
+  const years  = Math.floor(days / 365);
+  const months = Math.floor((days % 365) / 30);
+  if (years > 0 && months > 0) return `${years}年${months}ヶ月`;
+  if (years > 0) return `${years}年`;
+  if (months > 0) return `${months}ヶ月`;
+  return `${days}日`;
+};
+
+// ============================================================
+// カスタムツールチップ（tourLabel は API 側で生成済みのため join 不要）
+// ============================================================
+const CustomTooltip = ({ active, payload }: any) => {
+  if (!active || !payload?.length) return null;
+  const entry: YearlyPerformanceEntry = payload[0].payload;
+  return (
+    <div className="bg-slate-800 border border-slate-600 rounded-lg p-3 text-sm shadow-xl min-w-[160px]">
+      <div className="font-bold text-white mb-1">{entry.year}年</div>
+      <div className="text-blue-400 font-oswald text-lg">{entry.count}回</div>
+      {entry.tourLabel && (
+        <div className="text-slate-400 mt-1 text-xs leading-relaxed">
+          {entry.tourLabel}
+        </div>
+      )}
+      {entry.count === 0 && (
+        <div className="text-slate-600 text-xs mt-1">披露なし</div>
+      )}
+    </div>
+  );
+};
+
+// ============================================================
+// メタデータカード
+// ============================================================
+interface MetaCardProps {
+  label: string;
+  value: string;
+  sub?: string;
+  highlight?: boolean;
+  icon?: React.ReactNode;
+}
+
+const MetaCard: React.FC<MetaCardProps> = ({ label, value, sub, highlight, icon }) => (
+  <div className={`rounded-lg p-3 border ${
+    highlight
+      ? 'bg-amber-900/20 border-amber-500/30 text-amber-400'
+      : 'bg-slate-800/60 border-slate-700/50'
+  }`}>
+    <div className="flex items-center gap-1.5 text-slate-500 text-[10px] uppercase tracking-widest mb-1">
+      {icon}
+      {label}
+    </div>
+    <div className={`font-bold font-oswald text-base ${highlight ? 'text-amber-300' : 'text-white'}`}>
+      {value}
+    </div>
+    {sub && <div className="text-slate-500 text-[10px] mt-0.5 font-mono">{sub}</div>}
+  </div>
+);
+
+// ============================================================
+// メインコンポーネント
+// ============================================================
+const SongYearlyPerformanceChart: React.FC<Props> = ({ songId }) => {
+  const { data, isLoading, isError } = useSongPerformanceTimeline(songId);
+
+  // ローディング中
+  if (isLoading) {
+    return (
+      <div className="bg-slate-800/40 rounded-xl border border-slate-700/50 p-6 animate-pulse">
+        <div className="h-48 bg-slate-700/40 rounded-lg" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-16 bg-slate-700/40 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // エラー時は非表示（SongDetail.tsx 側のメインエラー表示に任せる）
+  if (isError || !data) return null;
+
+  const {
+    yearlyData,
+    firstPerformedAt,
+    lastPerformedAt,
+    longestGapDays,
+    longestGapStart,
+    longestGapEnd,
+    currentGapDays,
+    peakYear,
+    peakCount,
+    avgYearlyCount,
+    consecutiveYears,
+    totalPerformances,
+  } = data;
+
+  // 演奏実績がない場合は非表示
+  if (totalPerformances === 0) return null;
+
+  const maxCount = Math.max(...yearlyData.map(y => y.count), 1);
+
+  return (
+    <div className="bg-slate-800/40 rounded-xl border border-slate-700/50 p-6">
+
+      {/* ===== バーチャート ===== */}
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart
+          data={yearlyData}
+          margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+          barCategoryGap="20%"
+        >
+          <XAxis
+            dataKey="year"
+            tick={{ fill: '#64748b', fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            interval={yearlyData.length > 15 ? Math.floor(yearlyData.length / 8) : 0}
+          />
+          <YAxis
+            allowDecimals={false}
+            tick={{ fill: '#64748b', fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip
+            content={<CustomTooltip />}
+            cursor={{ fill: 'rgba(255,255,255,0.03)' }}
+          />
+          <Bar dataKey="count" radius={[3, 3, 0, 0]}>
+            {yearlyData.map((entry) => (
+              <Cell
+                key={`cell-${entry.year}`}
+                fill={getBarColor(entry.count, maxCount)}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      {/* ===== メタデータ帯 ===== */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
+        <MetaCard
+          label="初披露"
+          value={firstPerformedAt ?? '─'}
+          icon={<Calendar size={10} />}
+        />
+        <MetaCard
+          label="最終披露"
+          value={lastPerformedAt ?? '─'}
+          icon={<Calendar size={10} />}
+        />
+        <MetaCard
+          label="最長未披露期間"
+          value={longestGapDays ? formatDays(longestGapDays) : '─'}
+          sub={
+            longestGapStart && longestGapEnd
+              ? `${longestGapStart} 〜 ${longestGapEnd}`
+              : undefined
+          }
+          icon={<Clock size={10} />}
+        />
+        <MetaCard
+          label="現在未披露"
+          value={currentGapDays ? formatDays(currentGapDays) : '─'}
+          highlight={currentGapDays !== null && currentGapDays > 365}
+          icon={<Clock size={10} />}
+        />
+      </div>
+
+      {/* ===== 演奏密度メタ ===== */}
+      {(peakYear || avgYearlyCount || consecutiveYears) && (
+        <div className="flex flex-wrap gap-x-5 gap-y-1 mt-3 text-xs text-slate-500">
+          {peakYear && peakCount && (
+            <span className="flex items-center gap-1">
+              <Zap size={11} className="text-yellow-500" />
+              最多: <b className="text-slate-300 ml-0.5">{peakYear}年 ({peakCount}回)</b>
+            </span>
+          )}
+          {avgYearlyCount !== null && avgYearlyCount > 0 && (
+            <span className="flex items-center gap-1">
+              <TrendingUp size={11} className="text-blue-400" />
+              平均: <b className="text-slate-300 ml-0.5">{avgYearlyCount}回/年</b>
+            </span>
+          )}
+          {consecutiveYears && consecutiveYears > 1 && (
+            <span className="flex items-center gap-1">
+              🔥 連続披露: <b className="text-slate-300 ml-0.5">{consecutiveYears}年</b>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SongYearlyPerformanceChart;

--- a/src/hooks/queries/useSongPerformanceTimeline.ts
+++ b/src/hooks/queries/useSongPerformanceTimeline.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '../../lib/apiClient'
+import { queryKeys } from '../../lib/queryKeys'
+import type { SongPerformanceTimelineData } from '../../types/api'
+
+/**
+ * 楽曲演奏推移タイムラインデータを取得する React Query フック
+ *
+ * 取得先: GET /api/songs/:id/performance-timeline
+ * - 年別演奏回数の集計データ（欠番補完済み）
+ * - longestGap / currentGapDays / 演奏密度メタデータ
+ *
+ * キャッシュ戦略:
+ * - staleTime: 10分（セトリ追加直後に古いデータが残らないよう短めに設定）
+ * - gcTime: 1時間（メモリ上には1時間保持）
+ * - セトリ更新時は invalidateQueries(['song', id, 'performance-timeline']) で即時反映可能
+ */
+export const useSongPerformanceTimeline = (id: string | number | undefined) => {
+  const encodedId = id
+    ? encodeURIComponent(id.toString().replace(/\s+/g, ''))
+    : null
+
+  return useQuery({
+    queryKey: [...queryKeys.songs.detail(id), 'performance-timeline'],
+    queryFn: () =>
+      apiClient.get<SongPerformanceTimelineData>(
+        `/api/songs/${encodedId}/performance-timeline`
+      ),
+    staleTime: 1000 * 60 * 10,     // 10分
+    gcTime:    1000 * 60 * 60,     // 1時間
+    enabled: !!id,
+  })
+}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -417,7 +417,7 @@ function MyPage() {
                                             <Link
                                                 to={`/predictions/edit/${item.id}`}
                                                 onClick={(e) => e.stopPropagation()}
-                                                style={{ color: '#94a3b8', hover: { color: '#3b82f6' } }}
+                                                style={{ color: '#94a3b8' }}
                                                 className="edit-icon-btn"
                                             >
                                                 <Edit2 size={16} />

--- a/src/pages/SongDetail.tsx
+++ b/src/pages/SongDetail.tsx
@@ -5,6 +5,7 @@ import { Music, Calendar, MapPin, Play, Clock, ArrowLeft, Loader, Sparkles, Chev
 import ImageWithFallback from '../components/common/ImageWithFallback';
 import SEO from '../components/SEO';
 import { DISCOGRAPHY } from '../data/discography';
+import SongYearlyPerformanceChart from '../components/Visual/SongYearlyPerformanceChart';
 
 const SongDetail = () => {
     const { id } = useParams();
@@ -287,6 +288,16 @@ const SongDetail = () => {
                         )}
                     </div>
                 </div>
+
+                {/* PERFORMANCE TIMELINE チャート（演奏回数が1件以上の場合のみ表示） */}
+                {playCount > 0 && (
+                    <section className="mb-8">
+                        <h2 className="text-2xl font-bold font-oswald border-l-4 border-blue-500 pl-4 mb-6">
+                            PERFORMANCE TIMELINE
+                        </h2>
+                        <SongYearlyPerformanceChart songId={id} />
+                    </section>
+                )}
 
                 {/* Performance History Controls */}
                 <div id="performance-history" className="flex flex-col md:flex-row items-start md:items-center mb-6 gap-4">

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -219,3 +219,28 @@ export interface PublicUserProfile {
   is_following: boolean
   is_public: boolean
 }
+
+// 年別演奏データエントリ（楽曲演奏推移タイムライン用）
+export interface YearlyPerformanceEntry {
+  year: number
+  count: number
+  tours: string[]
+  hasMoreTours: boolean
+  tourLabel: string  // Tooltip表示用（API側で生成済み、フロント側で join しない）
+}
+
+// 楽曲演奏推移データ（GET /api/songs/:id/performance-timeline レスポンス）
+export interface SongPerformanceTimelineData {
+  totalPerformances: number
+  firstPerformedAt: string | null
+  lastPerformedAt: string | null
+  longestGapDays: number | null      // 連続する披露日の差分の最大値
+  longestGapStart: string | null
+  longestGapEnd: string | null
+  currentGapDays: number | null      // 最後の披露日から今日まで（Math.max(0, ...) 適用済み）
+  peakYear: number | null            // 最多披露年
+  peakCount: number | null           // 最多披露回数
+  avgYearlyCount: number | null      // 演奏あり年の平均演奏回数
+  consecutiveYears: number | null    // 最長連続披露年数
+  yearlyData: YearlyPerformanceEntry[]
+}


### PR DESCRIPTION
### 概要
楽曲詳細ページへの演奏推移チャート（PERFORMANCE TIMELINE）の追加と、AdminページのStatsタブで発生していたエラーの修正を行いました。

### 変更内容
#### 1. 演奏推移チャート (feat)
- バックエンド: \GET /api/songs/:id/performance-timeline\ エンドポイントの追加
- フロントエンド: Recharts を用いたタイムラインチャートコンポーネントの作成
- データ補完: 演奏がない年も0回として補完し、活動の歴史を正確に可視化

#### 2. Admin Statsバグ修正 (fix)
- バックエンド: \GET /api/stats/admin\ で特定のクエリが失敗してもエラー（500）にならないよう、フォールバック処理（デフォルト値の返却）を追加。
- これにより、検証環境などのDBで一部のテーブルが不足していてもStatsが表示されるようになりました。

### 確認事項
- [x] ローカル環境での動作確認
- [x] 検証環境（Staging）での動作確認
- [x] コンソールエラーがないこと