### PR TITLE
fix: Admin Stats の Nginx 404 回避対策

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -11,7 +11,10 @@ const formatDate = (dateStr) => {
     return `${year}.${month}.${day}`;
 };
 
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
+    if (req.query.admin === 'true') {
+        return next();
+    }
     try {
         const today = new Date().toISOString().split('T')[0];
 
@@ -196,8 +199,8 @@ router.get('/', async (req, res) => {
     }
 });
 
-// 管理者向けKPI統計
-router.get('/admin', authorize, adminCheck, async (req, res) => {
+// 管理者向けKPI統計（/api/stats?admin=true でアクセスされる）
+router.get('/', authorize, adminCheck, async (req, res) => {
     try {
         const queryWithFallback = async (queryStr, fallbackRows) => {
             try {

--- a/src/hooks/queries/useAdminStats.ts
+++ b/src/hooks/queries/useAdminStats.ts
@@ -37,7 +37,7 @@ export const useAdminStats = () =>
   useQuery({
     queryKey: queryKeys.admin.stats,
     queryFn: async () => {
-      const data: any = await apiClient.get('/api/stats/admin')
+      const data: any = await apiClient.get('/api/stats?admin=true')
       return data as AdminStats
     },
     staleTime: 60_000,


### PR DESCRIPTION
本番環境で \/api/stats/admin\ が 404 になる問題（Nginxのルーティング競合）を解決するため、エンドポイントを \/api/stats?admin=true\ に変更しました。