### PR TITLE
fix: dashboardの正規化ログ出力を抑制

### DIFF
--- a/src/lib/normalizers/dataNormalizer.ts
+++ b/src/lib/normalizers/dataNormalizer.ts
@@ -19,8 +19,8 @@ export function normalizeLive(raw: any): Live {
         };
     }
 
-    // 必須フィールドの欠落チェックとログ
-    if (!raw.id || !raw.tour_name || !raw.date) {
+    // 集計APIのネストされたライブ情報は tour_name を持たないため、ID/日付のみを必須扱いにする。
+    if (!raw.id || !raw.date) {
         console.warn('[Normalization] Potentially malformed live data detected:', raw);
     }
 


### PR DESCRIPTION
## 概要
Dashboard 初期表示時に正常な軽量ライブデータを大量に console.warn していたため、集計APIのネストされたライブ情報では tour_name 欠落を malformed 扱いしないようにします。

## 変更内容
- normalizeLive の警告条件を id/date 欠落のみに限定
- dashboard 初期表示時の大量ログ出力を抑制

## 確認
- npm run build 成功
- dev push 後の Run Tests 成功
- Deploy to Staging は確認時点で実行中

## 影響
- DB接続やAPIレスポンス自体の変更はありません
- フロントの正規化ログ出力のみを抑制します