### PR TITLE
feat: 年別夏フェス分析を追加

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -133,7 +133,9 @@ router.get('/', async (req, res) => {
             upcomingRes,
             songFreqRes,
             tourBaseRes,
-            tourSongsRes
+            tourSongsRes,
+            summerFestivalBaseRes,
+            summerFestivalSongsRes
         ] = await Promise.all([
             // 基本集計
             db.query(`
@@ -230,6 +232,42 @@ router.get('/', async (req, res) => {
                         OR (UPPER(l.tour_name) NOT LIKE '%FES.%' AND UPPER(l.tour_name) NOT LIKE '%FESTIVAL%')
                     )
                 GROUP BY COALESCE(l.tour_name, l.title), s.title, s.id
+            `),
+
+            // 年別夏フェス基本統計（7-9月のFESTIVALを年単位で集約）
+            db.query(`
+                SELECT
+                    EXTRACT(YEAR FROM date)::text as year,
+                    COUNT(*)::int as live_count,
+                    MIN(date)::text as start_date,
+                    MAX(date)::text as end_date,
+                    MAX(date)::text as latest_date
+                FROM lives
+                WHERE (setlist_status = 'NORMAL' OR EXISTS (SELECT 1 FROM setlists sl_sub WHERE sl_sub.live_id = lives.id))
+                    AND type = 'FESTIVAL'
+                    AND EXTRACT(MONTH FROM date) BETWEEN 7 AND 9
+                GROUP BY EXTRACT(YEAR FROM date)
+                ORDER BY MAX(date) DESC
+            `),
+
+            // 年別夏フェス楽曲ランキング
+            db.query(`
+                SELECT
+                    EXTRACT(YEAR FROM l.date)::text as year,
+                    s.title as song_title,
+                    s.id as song_id,
+                    COUNT(sl.id)::int as count,
+                    JSON_AGG(
+                        JSON_BUILD_OBJECT('id', l.id, 'date', l.date::text, 'venue', l.venue, 'title', COALESCE(l.tour_name, l.title))
+                        ORDER BY l.date DESC
+                    ) as lives
+                FROM lives l
+                JOIN setlists sl ON l.id = sl.live_id
+                JOIN songs s ON sl.song_id = s.id
+                WHERE (l.setlist_status = 'NORMAL' OR EXISTS (SELECT 1 FROM setlists sl_sub WHERE sl_sub.live_id = l.id))
+                    AND l.type = 'FESTIVAL'
+                    AND EXTRACT(MONTH FROM l.date) BETWEEN 7 AND 9
+                GROUP BY EXTRACT(YEAR FROM l.date), s.title, s.id
             `)
         ]);
 
@@ -276,6 +314,36 @@ router.get('/', async (req, res) => {
             latestDate: formatDate(tour.latest_date)
         }));
 
+        // 年別夏フェスランキング構築
+        const summerFestivalLiveCountMap = {};
+        summerFestivalBaseRes.rows.forEach(festival => {
+            summerFestivalLiveCountMap[festival.year] = festival.live_count;
+        });
+
+        const summerFestivalSongMap = {};
+        summerFestivalSongsRes.rows.forEach(row => {
+            const year = row.year;
+            if (!summerFestivalSongMap[year]) summerFestivalSongMap[year] = [];
+            const liveCount = summerFestivalLiveCountMap[year] || 1;
+            summerFestivalSongMap[year].push({
+                title: row.song_title,
+                count: row.count,
+                lives: row.lives,
+                percentage: ((row.count / liveCount) * 100).toFixed(1)
+            });
+        });
+
+        const summerFestivalRanking = summerFestivalBaseRes.rows.map(festival => ({
+            name: `${festival.year} 夏フェス`,
+            year: festival.year,
+            liveCount: festival.live_count,
+            totalSongs: (summerFestivalSongMap[festival.year] || []).reduce((sum, s) => sum + s.count, 0),
+            songRanking: (summerFestivalSongMap[festival.year] || []).sort((a, b) => b.count - a.count),
+            startDate: formatDate(festival.start_date),
+            endDate: formatDate(festival.end_date),
+            latestDate: formatDate(festival.latest_date)
+        }));
+
         res.json({
             totalLives,
             totalSongsPerformed: basic.total_songs_performed,
@@ -297,6 +365,7 @@ router.get('/', async (req, res) => {
             })),
             globalSongRanking,
             tourRanking,
+            summerFestivalRanking,
             currentTour: tourRanking[0] || null,
             songFrequencyMap
         });

--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -34,6 +34,7 @@ interface StatsResponse {
         percentage: string;
     }>;
     tourRanking: any[];
+    summerFestivalRanking: any[];
     currentTour: any | null;
     songFrequencyMap: Record<string, number>;
 }
@@ -61,6 +62,13 @@ export const useGlobalStats = () => {
                 ...normalizeSong(s)
             })),
             tourRanking: (rawStatsData.tourRanking || []).map(t => ({
+                ...t,
+                songRanking: (t.songRanking || []).map((s: any) => ({
+                    ...s,
+                    lives: (s.lives || []).map((l: any) => normalizeLive(l))
+                }))
+            })),
+            summerFestivalRanking: (rawStatsData.summerFestivalRanking || []).map(t => ({
                 ...t,
                 songRanking: (t.songRanking || []).map((s: any) => ({
                     ...s,
@@ -145,6 +153,7 @@ export const useGlobalStats = () => {
         upcomingLives: statsData?.upcomingLives ?? [],
         globalSongRanking: statsData?.globalSongRanking ?? [],
         tourRanking: statsData?.tourRanking ?? [],
+        summerFestivalRanking: statsData?.summerFestivalRanking ?? [],
         currentTour: statsData?.currentTour ?? null,
         songFrequencyMap: statsData?.songFrequencyMap ?? {},
         ...derived,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -198,7 +198,6 @@ function Dashboard() {
     };
 
     const [selectedAnalysisTour, setSelectedAnalysisTour] = useState<any>(null);
-    const [selectedSummerFestival, setSelectedSummerFestival] = useState<any>(null);
 
     // Set default analysis tour when data loads
     React.useEffect(() => {
@@ -208,11 +207,6 @@ function Dashboard() {
         }
     }, [stats.tourRanking]);
 
-    React.useEffect(() => {
-        if (stats.summerFestivalRanking && stats.summerFestivalRanking.length > 0 && !selectedSummerFestival) {
-            setSelectedSummerFestival(stats.summerFestivalRanking[0]);
-        }
-    }, [stats.summerFestivalRanking]);
 
     if (loading) return (
         <div style={{ padding: '100px', textAlign: 'center', color: '#888' }}>
@@ -228,6 +222,12 @@ function Dashboard() {
         { id: 'liveCount', label: 'ライブ数', icon: <Calendar size={14} /> },
         { id: 'totalSongs', label: '総披露曲数', icon: <Music size={14} /> },
     ];
+
+    const selectedAnalysisValue = selectedAnalysisTour?.year
+        ? `summer:${selectedAnalysisTour.year}`
+        : selectedAnalysisTour?.name
+            ? `tour:${selectedAnalysisTour.name}`
+            : '';
 
     return (
         <div className="page-wrapper">
@@ -551,59 +551,6 @@ function Dashboard() {
                 </div>
 
 
-                {/* Summer Festival Analysis */}
-                <div style={{ marginTop: '60px', marginBottom: '60px' }}>
-                    <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <Music size={20} color="var(--primary-color)" />
-                        Summer Festival Analysis
-                    </h2>
-
-                    <div className="dashboard-panel">
-                        <div style={{ marginBottom: '20px' }}>
-                            <label style={{ display: 'block', color: '#94a3b8', marginBottom: '8px', fontSize: '0.9rem' }}>Select Year</label>
-                            <select
-                                value={selectedSummerFestival ? selectedSummerFestival.year : ''}
-                                onChange={(e) => {
-                                    const festival = stats.summerFestivalRanking?.find((item: any) => item.year === e.target.value);
-                                    setSelectedSummerFestival(festival);
-                                }}
-                                style={{
-                                    width: '100%',
-                                    padding: '12px',
-                                    borderRadius: '8px',
-                                    background: '#1e293b',
-                                    border: '1px solid rgba(255,255,255,0.2)',
-                                    color: '#fff',
-                                    fontSize: '1rem',
-                                    outline: 'none',
-                                    appearance: 'none',
-                                    backgroundImage: `url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23FFFFFF%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E")`,
-                                    backgroundRepeat: 'no-repeat',
-                                    backgroundPosition: 'right 12px top 50%',
-                                    backgroundSize: '12px auto',
-                                    cursor: 'pointer'
-                                }}
-                            >
-                                {(stats.summerFestivalRanking || []).map((festival: any) => (
-                                    <option key={festival.year} value={festival.year} style={{ background: '#1e293b', color: '#fff' }}>
-                                        {festival.name} ({festival.startDate} ~ {festival.endDate} / {festival.liveCount} shows)
-                                    </option>
-                                ))}
-                            </select>
-                        </div>
-
-                        {selectedSummerFestival ? (
-                            <ErrorBoundary>
-                                <TourTrends tour={selectedSummerFestival} />
-                            </ErrorBoundary>
-                        ) : (
-                            <div style={{ padding: '40px', textAlign: 'center', color: '#64748b' }}>
-                                夏フェスのセットリストデータがありません
-                            </div>
-                        )}
-                    </div>
-                </div>
-
                 {/* Past Tour Analysis (New Section) */}
                 <div style={{ marginTop: '60px', marginBottom: '100px' }}>
                     <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
@@ -615,9 +562,18 @@ function Dashboard() {
                         <div style={{ marginBottom: '20px' }}>
                             <label style={{ display: 'block', color: '#94a3b8', marginBottom: '8px', fontSize: '0.9rem' }}>Select Tour</label>
                             <select
-                                value={selectedAnalysisTour ? selectedAnalysisTour.name : ''}
+                                value={selectedAnalysisValue}
                                 onChange={(e) => {
-                                    const tour = stats.tourRanking?.find((t: any) => t.name === e.target.value);
+                                    const value = e.target.value;
+                                    if (value.startsWith('summer:')) {
+                                        const year = value.replace('summer:', '');
+                                        const festival = stats.summerFestivalRanking?.find((item: any) => item.year === year);
+                                        setSelectedAnalysisTour(festival);
+                                        return;
+                                    }
+
+                                    const tourName = value.replace('tour:', '');
+                                    const tour = stats.tourRanking?.find((t: any) => t.name === tourName);
                                     setSelectedAnalysisTour(tour);
                                 }}
                                 style={{
@@ -638,25 +594,39 @@ function Dashboard() {
                                 }}
                             >
                                 {(() => {
-                                    if (!stats.tourRanking) return null;
                                     const groups: Record<string, any[]> = {};
-                                    stats.tourRanking.forEach((tour: any) => {
+
+                                    (stats.summerFestivalRanking || []).forEach((festival: any) => {
+                                        const year = String(festival.year);
+                                        if (!groups[year]) groups[year] = [];
+                                        groups[year].push({ ...festival, analysisType: 'summer' });
+                                    });
+
+                                    (stats.tourRanking || []).forEach((tour: any) => {
                                         const year = tour.startDate.split('.')[0];
                                         if (!groups[year]) groups[year] = [];
-                                        groups[year].push(tour);
+                                        groups[year].push({ ...tour, analysisType: 'tour' });
                                     });
 
                                     return Object.entries(groups)
                                         .sort((a, b) => b[0].localeCompare(a[0]))
-                                        .map(([year, tours]) => (
-                                            <optgroup key={year} label={`${year}`} style={{ color: '#94a3b8', background: '#0f172a' }}>
-                                                {tours.map((tour: any, idx: number) => (
-                                                    <option key={`${year}-${idx}`} value={tour.name} style={{ background: '#1e293b', color: '#fff' }}>
-                                                        {tour.name} ({tour.startDate} ~ {tour.endDate} / {tour.liveCount} shows)
-                                                    </option>
-                                                ))}
-                                            </optgroup>
-                                        ));
+                                        .map(([year, items]) => {
+                                            const sortedItems = [...items].sort((a: any, b: any) => a.startDate.localeCompare(b.startDate));
+
+                                            return (
+                                                <optgroup key={year} label={`${year}`} style={{ color: '#94a3b8', background: '#0f172a' }}>
+                                                    {sortedItems.map((item: any, idx: number) => (
+                                                        <option
+                                                            key={`${year}-${item.analysisType}-${idx}`}
+                                                            value={item.analysisType === 'summer' ? `summer:${item.year}` : `tour:${item.name}`}
+                                                            style={{ background: '#1e293b', color: '#fff' }}
+                                                        >
+                                                            {item.analysisType === 'summer' ? '夏フェス: ' : ''}{item.name} ({item.startDate} ~ {item.endDate} / {item.liveCount} shows)
+                                                        </option>
+                                                    ))}
+                                                </optgroup>
+                                            );
+                                        });
                                 })()}
                             </select>
                         </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -198,6 +198,7 @@ function Dashboard() {
     };
 
     const [selectedAnalysisTour, setSelectedAnalysisTour] = useState<any>(null);
+    const [selectedSummerFestival, setSelectedSummerFestival] = useState<any>(null);
 
     // Set default analysis tour when data loads
     React.useEffect(() => {
@@ -206,6 +207,12 @@ function Dashboard() {
             setSelectedAnalysisTour(stats.tourRanking[0]);
         }
     }, [stats.tourRanking]);
+
+    React.useEffect(() => {
+        if (stats.summerFestivalRanking && stats.summerFestivalRanking.length > 0 && !selectedSummerFestival) {
+            setSelectedSummerFestival(stats.summerFestivalRanking[0]);
+        }
+    }, [stats.summerFestivalRanking]);
 
     if (loading) return (
         <div style={{ padding: '100px', textAlign: 'center', color: '#888' }}>
@@ -540,6 +547,60 @@ function Dashboard() {
                                 })()} onBarClick={handleAlbumClick} />
                             </ErrorBoundary>
                         </div>
+                    </div>
+                </div>
+
+
+                {/* Summer Festival Analysis */}
+                <div style={{ marginTop: '60px', marginBottom: '60px' }}>
+                    <h2 className="section-title" style={{ marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '10px' }}>
+                        <Music size={20} color="var(--primary-color)" />
+                        Summer Festival Analysis
+                    </h2>
+
+                    <div className="dashboard-panel">
+                        <div style={{ marginBottom: '20px' }}>
+                            <label style={{ display: 'block', color: '#94a3b8', marginBottom: '8px', fontSize: '0.9rem' }}>Select Year</label>
+                            <select
+                                value={selectedSummerFestival ? selectedSummerFestival.year : ''}
+                                onChange={(e) => {
+                                    const festival = stats.summerFestivalRanking?.find((item: any) => item.year === e.target.value);
+                                    setSelectedSummerFestival(festival);
+                                }}
+                                style={{
+                                    width: '100%',
+                                    padding: '12px',
+                                    borderRadius: '8px',
+                                    background: '#1e293b',
+                                    border: '1px solid rgba(255,255,255,0.2)',
+                                    color: '#fff',
+                                    fontSize: '1rem',
+                                    outline: 'none',
+                                    appearance: 'none',
+                                    backgroundImage: `url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23FFFFFF%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E")`,
+                                    backgroundRepeat: 'no-repeat',
+                                    backgroundPosition: 'right 12px top 50%',
+                                    backgroundSize: '12px auto',
+                                    cursor: 'pointer'
+                                }}
+                            >
+                                {(stats.summerFestivalRanking || []).map((festival: any) => (
+                                    <option key={festival.year} value={festival.year} style={{ background: '#1e293b', color: '#fff' }}>
+                                        {festival.name} ({festival.startDate} ~ {festival.endDate} / {festival.liveCount} shows)
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+
+                        {selectedSummerFestival ? (
+                            <ErrorBoundary>
+                                <TourTrends tour={selectedSummerFestival} />
+                            </ErrorBoundary>
+                        ) : (
+                            <div style={{ padding: '40px', textAlign: 'center', color: '#64748b' }}>
+                                夏フェスのセットリストデータがありません
+                            </div>
+                        )}
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- 年別の夏フェスセットリスト集計を stats API に追加
- Dashboard の Past Tour Analysis に夏フェス分析を統合
- 年グループ内でツアーと夏フェスを日付順に表示

## Verification
- npm run build
- Run Tests: success on dev
- Deploy to Staging: success on dev
- 検証環境で動作確認済み