### PR TITLE
fix: migration table存在確認で権限エラーを回避

### DIFF
--- a/server/scripts/migrate.js
+++ b/server/scripts/migrate.js
@@ -36,6 +36,11 @@ const pool = new Pool({
  * schema_migrations テーブルを作成する（存在しない場合のみ）
  */
 async function ensureMigrationTable(client) {
+    const existing = await client.query("SELECT to_regclass('schema_migrations') AS table_name");
+    if (existing.rows[0].table_name) {
+        return;
+    }
+
     await client.query(`
         CREATE TABLE IF NOT EXISTS schema_migrations (
             id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- schema_migrations が既に存在する場合は CREATE TABLE IF NOT EXISTS を実行しない
- public schema の CREATE 権限がない本番DBでも migration 確認を継続できるようにする

## Context
- v1.20.4 Production deploy が node scripts/migrate.js で permission denied for schema public により失敗
- 本番DBでは schema_migrations は存在済み、適用済み件数は24件、DBユーザーは public CREATE 権限なし

## Verification
- node --check server/scripts/migrate.js
- npm run build
- Run Tests: success on dev
- Deploy to Staging: success on dev